### PR TITLE
Add missing Doxygen reference directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the genogrove documentation project will be documented in this file.
 
+## 2026-02-26
+
+### Changed
+- Extended GFF/GTF section in I/O guide with precise field types, format detection explanation, coordinate conversion note, attribute access patterns with fallback behavior, GTF validation rules, and convenience methods ([#26](https://github.com/genogrove/docs/pull/26))
+
+### Issues filed
+- [#24](https://github.com/genogrove/docs/issues/24) — Add GFF/GTF grove loading example to grove user guide
+- [#25](https://github.com/genogrove/docs/issues/25) — Add BAM/SAM grove loading example to grove user guide
+
 ## 2026-02-25
 
 ### Added

--- a/source/reference/cpp/data_type.md
+++ b/source/reference/cpp/data_type.md
@@ -34,28 +34,42 @@ The `genogrove::data_type` namespace contains genomic data type definitions and 
    :undoc-members:
 ```
 
-% .. index
+## numeric
 
-% .. -----
+```{eval-rst}
+.. doxygenclass:: genogrove::data_type::numeric
+   :members:
+   :undoc-members:
+```
 
-% ..
+## kmer
 
-% .. .. doxygenclass:: genogrove::data_type::index
+```{eval-rst}
+.. doxygenclass:: genogrove::data_type::kmer
+   :members:
+   :undoc-members:
+```
 
-% ..    :members:
+## data_registry
 
-% ..    :undoc-members:
+```{eval-rst}
+.. doxygenclass:: genogrove::data_type::data_registry
+   :members:
+   :undoc-members:
+```
 
-% ..
+## index
 
-% .. index_registry
+```{eval-rst}
+.. doxygenclass:: genogrove::data_type::index
+   :members:
+   :undoc-members:
+```
 
-% .. --------------
+## index_registry
 
-% ..
-
-% .. .. doxygenclass:: genogrove::data_type::index_registry
-
-% ..    :members:
-
-% ..    :undoc-members:
+```{eval-rst}
+.. doxygenclass:: genogrove::data_type::index_registry
+   :members:
+   :undoc-members:
+```

--- a/source/reference/cpp/io.md
+++ b/source/reference/cpp/io.md
@@ -2,23 +2,17 @@
 
 The `genogrove::io` namespace contains file readers and parsers for genomic file formats.
 
-## file_reader_base
+## Readers
+
+### filetype_detector
 
 ```{eval-rst}
-.. doxygenclass:: genogrove::io::file_reader_base
+.. doxygenclass:: genogrove::io::filetype_detector
    :members:
    :undoc-members:
 ```
 
-## file_reader
-
-```{eval-rst}
-.. doxygenclass:: genogrove::io::file_reader
-   :members:
-   :undoc-members:
-```
-
-## bed_reader
+### bed_reader
 
 ```{eval-rst}
 .. doxygenclass:: genogrove::io::bed_reader
@@ -26,7 +20,7 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
-## gff_reader
+### gff_reader
 
 ```{eval-rst}
 .. doxygenclass:: genogrove::io::gff_reader
@@ -34,17 +28,97 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
-## bam_reader
+### bam_reader
+
 ```{eval-rst}
 .. doxygenclass:: genogrove::io::bam_reader
    :members:
    :undoc-members:
 ```
 
-## filetype_detector
+
+## Entry Types
+
+### bed_entry
 
 ```{eval-rst}
-.. doxygenclass:: genogrove::io::filetype_detector
+.. doxygenclass:: genogrove::io::bed_entry
    :members:
    :undoc-members:
+```
+
+### gff_entry
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::gff_entry
+   :members:
+   :undoc-members:
+```
+
+### sam_entry
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::sam_entry
+   :members:
+   :undoc-members:
+```
+
+## BAM/SAM Types
+
+### alignment_flags
+
+```{eval-rst}
+.. doxygenclass:: genogrove::io::alignment_flags
+   :members:
+   :undoc-members:
+```
+
+### bam_reader_options
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::bam_reader_options
+   :members:
+   :undoc-members:
+```
+
+### cigar_element
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::cigar_element
+   :members:
+   :undoc-members:
+```
+
+### mate_info
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::mate_info
+   :members:
+   :undoc-members:
+```
+
+## Enums
+
+### filetype
+
+```{eval-rst}
+.. doxygenenum:: genogrove::io::filetype
+```
+
+### compression_type
+
+```{eval-rst}
+.. doxygenenum:: genogrove::io::compression_type
+```
+
+### gff_format
+
+```{eval-rst}
+.. doxygenenum:: genogrove::io::gff_format
+```
+
+### cigar_op
+
+```{eval-rst}
+.. doxygenenum:: genogrove::io::cigar_op
 ```


### PR DESCRIPTION
## Summary
- Adds missing Doxygen directives for user-facing API types in `io.md` and `data_type.md`
- Removes internal base classes (`file_reader_base`, `file_reader`) from the reference
- Organizes `io.md` into sections: Readers, Entry Types, BAM/SAM Types, Enums
- Re-enables `index` and `index_registry` in `data_type.md` (were commented out)
- Adds `numeric`, `kmer`, and `data_registry` to `data_type.md`

Closes #12 (partially — skips internal framework types like `type_registry`, `serialization_traits`, `any_base`/`any_type`, and `utility.md`)

## Test plan
- [x] Run `make clean && make html` — verify no Sphinx/Breathe warnings
- [x] Visual review of rendered reference pages for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized C++ data type reference documentation with explicit sections and improved formatting for better navigation.
  * Enhanced C++ I/O namespace documentation with restructured sections, expanded type references, and new subsections for entry and enum types.
  * Updated CHANGELOG to reflect recent I/O guide updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->