### PR TITLE
Fix navigation: orphaned guide pages not in toctree

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -92,6 +92,7 @@ html_theme_options = {
     "navbar_end": ["navbar-icon-links"],
     "navbar_persistent": ["search-button"],
     "show_toc_level": 3,
+    "show_nav_level": 2,
     "navigation_depth": 4,
     "icon_links": [
         {

--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -207,7 +207,7 @@ int main() {
 - Aggregation: Returns k-mer with maximum encoding
 
 ```{toctree}
-:hidden:
+:maxdepth: 1
 
 data_types/key
 data_types/data_registry

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -1,6 +1,11 @@
-# The Grove Data Structure
+# Grove
 
-The `grove` is a specialized B+ tree optimized for genomic interval storage and querying. It includes an embedded graph overlay that allows you to link keys within the grove, creating relationships between genomic features.
+The `grove` is a specialized B+ tree optimized for genomic interval storage and querying. It organizes data by index (e.g., chromosome) and supports efficient overlap queries. An embedded graph overlay allows you to create directed edges between keys, representing relationships between genomic features.
+
+Beyond the core data structure covered on this page, the grove also supports:
+
+- **{doc}`graph`** — Create directed edges between keys to represent relationships such as transcript structures or gene regulatory networks
+- **{doc}`graph_manipulation`** — Inspect, modify, and analyze the graph structure with operations for edge management, neighbor traversal, and graph statistics
 
 ## Key Types and the key_type_base Concept
 

--- a/source/user_guide.md
+++ b/source/user_guide.md
@@ -13,7 +13,7 @@ Before starting, ensure you have:
 ## Guide Contents
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 3
 
 guide/installation
 guide/io


### PR DESCRIPTION
## Summary
- Bump `user_guide.md` toctree `maxdepth` from 2 to 3 so grove sub-pages (Linking Keys, Graph Manipulation) appear in the sidebar
- Replace `:hidden:` with `:maxdepth: 1` in `data_types.md` toctree so Key and Data Registry sub-pages are visible in navigation
- Set `show_nav_level: 2` in pydata_sphinx_theme options to expand the sidebar one level by default
- Add cross-references to Linking Keys and Graph Manipulation at the top of the grove page so users know they exist

Closes #13

## Test plan
- [x] Run `make clean && make html` — verify no Sphinx build warnings
- [x] Verify grove sub-pages (Linking Keys, Graph Manipulation) are visible in sidebar without expanding
- [x] Verify data type sub-pages (Key, Data Registry) are visible in sidebar without expanding
- [ ] Verify cross-reference links on grove page render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Improved documentation navigation structure with enhanced depth control for better browsing experience
* Updated Grove data structure documentation with clarified terminology and expanded content
* Enhanced table of contents visibility across guide sections for easier navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->