### PR TITLE
Remove stale sphinx-immaterial dependency

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,6 +1,5 @@
 sphinx>=7.0,<9.0
 breathe>=4.35.0
-sphinx-immaterial>=0.11.0
 pydata-sphinx-theme
 myst-parser>=4.0.0
 linkify-it-py>=2.0.0


### PR DESCRIPTION
## Summary
- Removes unused `sphinx-immaterial` from `requirements.txt` — the project uses `pydata-sphinx-theme`
- The version mismatch item from this issue was already resolved in #22

Closes #14

## Test plan
- [ ] Run `pip install -r source/requirements.txt && make clean && make html` — verify build succeeds without sphinx-immaterial

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined project dependencies by removing the sphinx-immaterial package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->