### PR TITLE
Document non-copyable/movable pattern for file readers

### DIFF
--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -2,6 +2,30 @@
 
 The `genogrove::io` namespace provides efficient readers for common genomic file formats with automatic compression detection.
 
+## Reader Ownership
+
+All file readers (`bed_reader`, `gff_reader`, `bam_reader`) own raw htslib resource pointers and are
+**non-copyable** but **movable**. Attempting to copy a reader will produce a compile error.
+
+```cpp
+namespace gio = genogrove::io;
+
+gio::bed_reader reader("data.bed");
+
+// gio::bed_reader copy = reader;            // compile error — not copyable
+gio::bed_reader moved = std::move(reader);   // OK — transfers ownership
+```
+
+When passing readers to functions, use a reference or move them:
+
+```cpp
+namespace gio = genogrove::io;
+
+void process(gio::bed_reader& reader) {      // pass by reference
+    for (const auto& entry : reader) { /* ... */ }
+}
+```
+
 ## Automatic File Type Detection
 
 Genogrove can automatically detect file types and compression formats:


### PR DESCRIPTION
## Summary
- Adds "Reader Ownership" section to the top of the I/O guide
- Documents that all readers are non-copyable but movable (htslib resource ownership)
- Shows examples for `std::move` and pass-by-reference patterns

Closes #17

## Test plan
- [x] Run `make clean && make html` — verify no Sphinx build warnings
- [x] Visual review of the rendered Reader Ownership section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ownership and usage patterns for file readers, explaining their move-only behavior and recommended ways to pass them in code. Includes examples and keeps existing automatic file type detection guidance intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->