### PR TITLE
Document error handling pattern for file readers

### DIFF
--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -64,6 +64,39 @@ int main() {
 - ZSTD (.zst)
 - LZ4 (.lz4)
 
+## Error Handling
+
+All file readers silently stop iteration on both end-of-file and parse errors. A malformed line
+will end the loop early without raising an exception. Always check `get_error_message()` after the
+loop to detect parse failures:
+
+```cpp
+namespace gio = genogrove::io;
+
+gio::bed_reader reader("data.bed");
+
+for (const auto& entry : reader) {
+    // process entries...
+}
+
+// Distinguish successful EOF from a parse error
+if (!reader.get_error_message().empty()) {
+    std::cerr << "Parse error: " << reader.get_error_message() << "\n";
+    // error messages include the line number, e.g.
+    // "Invalid coordinate format at line 42"
+}
+```
+
+This pattern applies to all readers (`bed_reader`, `gff_reader`, `bam_reader`).
+
+```{note}
+A future release will change this behavior: readers will throw `std::runtime_error` on parse
+errors by default, so malformed lines no longer silently truncate iteration. See
+[genogrove/genogrove#68](https://github.com/genogrove/genogrove/issues/68),
+[genogrove/genogrove#102](https://github.com/genogrove/genogrove/issues/102), and
+[genogrove/genogrove#110](https://github.com/genogrove/genogrove/issues/110) for details.
+```
+
 ## BED Files
 
 BED files store genomic intervals with optional metadata. The `bed_reader` provides iterator-based access:


### PR DESCRIPTION
## Summary
- Added Error Handling section to the I/O guide between Reader Ownership and BED Files
- Documents the `get_error_message()` post-loop check pattern to detect parse failures
- Includes a note that future releases will throw on parse errors instead (genogrove/genogrove#110)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Error Handling" section for automatic file-type detection. Explains that readers silently stop iteration on end-of-file and parse errors, instructs users to inspect post-iteration error messages to detect parse failures, includes an example distinguishing EOF from parse errors, and notes that a future release will switch to throwing exceptions for parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->