### PR TITLE
Document bam_reader header access methods

### DIFF
--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -356,6 +356,30 @@ if (it != entry.tags.end()) {
 }
 ```
 
+### Header Access
+
+The `bam_reader` provides methods to inspect the SAM header and reference sequences before or after iteration:
+
+- `get_header()` — returns the full SAM header text (all `@HD`, `@SQ`, `@RG`, `@PG` lines)
+- `get_reference_names()` — returns a `std::vector<std::string>` of reference sequence names from the header
+
+```cpp
+namespace gio = genogrove::io;
+
+gio::bam_reader reader("alignments.bam");
+
+// Inspect reference sequences
+const auto& refs = reader.get_reference_names();
+std::cout << "References (" << refs.size() << "):\n";
+for (const auto& name : refs) {
+    std::cout << "  " << name << "\n";
+}
+
+// Access the raw SAM header (e.g., to find read groups)
+const std::string& header = reader.get_header();
+std::cout << "Header:\n" << header << "\n";
+```
+
 ### Convenience Methods
 
 - `get_strand()` — returns `'+'`, `'-'`, or `'.'`


### PR DESCRIPTION
## Summary
- Add a **Header Access** subsection to the BAM/SAM section of the I/O guide documenting `get_header()` and `get_reference_names()`
- Include a usage example showing how to enumerate reference sequences and inspect the raw SAM header

Closes #36

## Test plan
- [x] Run `make clean && make html` and verify no Sphinx build warnings
- [x] Confirm the new subsection renders correctly under BAM/SAM → Header Access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Header Access" section to BAM/IO documentation, documenting accessor methods for readers with practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->