### PR TITLE
Add missing Doxygen directives for BED/BAM support types and serialization utilities

### DIFF
--- a/source/reference/cpp/data_type.md
+++ b/source/reference/cpp/data_type.md
@@ -73,3 +73,21 @@ The `genogrove::data_type` namespace contains genomic data type definitions and 
    :members:
    :undoc-members:
 ```
+
+## Serialization Utilities
+
+### serialization_traits
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::data_type::serialization_traits
+   :members:
+   :undoc-members:
+```
+
+### serializer
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::data_type::serializer
+   :members:
+   :undoc-members:
+```

--- a/source/reference/cpp/io.md
+++ b/source/reference/cpp/io.md
@@ -63,7 +63,41 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
+## BED Support Types
+
+### rgb_color
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::rgb_color
+   :members:
+   :undoc-members:
+```
+
+### thick_info
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::thick_info
+   :members:
+   :undoc-members:
+```
+
+### block_info
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::block_info
+   :members:
+   :undoc-members:
+```
+
 ## BAM/SAM Types
+
+### sam_flags
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::sam_flags
+   :members:
+   :undoc-members:
+```
 
 ### alignment_flags
 
@@ -93,6 +127,14 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
 
 ```{eval-rst}
 .. doxygenstruct:: genogrove::io::mate_info
+   :members:
+   :undoc-members:
+```
+
+### sam_tag
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::sam_tag
    :members:
    :undoc-members:
 ```


### PR DESCRIPTION
## Summary
- Add **BED Support Types** section to I/O API reference: `rgb_color`, `thick_info`, `block_info`
- Add `sam_flags` and `sam_tag` to **BAM/SAM Types** section in I/O API reference
- Add **Serialization Utilities** section to data type API reference: `serialization_traits`, `serializer`

Closes #37

## Test plan
- [x] Run `make clean && make html` and verify no Sphinx/Breathe build warnings
- [x] Confirm new directives render correctly in the API reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced C++ API reference with documentation for new serialization utilities in the data type module
  * Added reference documentation for BED format support types: rgb_color, thick_info, and block_info
  * Added reference documentation for BAM/SAM format types: sam_flags and sam_tag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->