### PR TITLE
Fix examples that discard [[nodiscard]] return values

### DIFF
--- a/source/guide/data_types/data_registry.md
+++ b/source/guide/data_types/data_registry.md
@@ -25,10 +25,10 @@ int main() {
     uint32_t id2 = registry.register_data(SampleInfo{"sample2", "kidney", 1});
 
     // 3. Check registry state
-    registry.size();      // 2
-    registry.empty();     // false
-    registry.contains(id1);  // true
-    registry.contains(999);  // false
+    size_t count = registry.size();          // 2
+    bool is_empty = registry.empty();        // false
+    bool has_id1 = registry.contains(id1);   // true
+    bool has_999 = registry.contains(999);   // false
 
     // 4. Retrieve data by ID (returns pointer, nullptr if invalid)
     const SampleInfo* info = registry.get(id1);

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -83,13 +83,13 @@ int main() {
     registry.clear();
     {
         std::ifstream in("data.bin", std::ios::binary);
-        gdt::data_registry<std::string>::deserialize(in);
+        auto& restored = gdt::data_registry<std::string>::deserialize(in);
         auto loaded = gst::grove<gdt::interval, uint32_t>::deserialize(in);
 
         // Registry IDs in the grove still resolve correctly
         auto results = loaded.intersect(gdt::interval{100, 200}, "chr1");
         for (auto* key : results.get_keys()) {
-            auto* name = registry.get(key->get_data());  // "SampleA_liver"
+            auto* name = restored.get(key->get_data());  // "SampleA_liver"
         }
     }
 


### PR DESCRIPTION
## Summary
- **serialization.md**: Capture `data_registry::deserialize()` return value and use it for subsequent `get()` calls
- **data_registry.md**: Capture return values from `size()`, `empty()`, and `contains()` into named variables

These examples would now produce compiler warnings after the `[[nodiscard]]` annotations added in genogrove/genogrove#119.

Closes #40

## Test plan
- [ ] Run `make clean && make html` and verify no Sphinx build warnings
- [ ] Verify the updated examples are correct and compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data registry guide with improved examples showcasing how to capture method return values into properly typed variables
  * Enhanced serialization guide with refined examples demonstrating optimal handling and reuse of deserialized registry objects in persistence workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->