### PR TITLE
Update intersect() examples for const ref parameter

### DIFF
--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -251,9 +251,8 @@ int main() {
     my_grove.insert_data("chr1", gdt::interval{300, 400}, "gene3");
     my_grove.insert_data("chr2", gdt::interval{100, 200}, "gene4");
 
-    // Query specific chromosome
-    gdt::interval query{175, 225};
-    auto results = my_grove.intersect(query, "chr1");
+    // Query specific chromosome (temporaries work directly)
+    auto results = my_grove.intersect(gdt::interval{175, 225}, "chr1");
 
     // Process results
     for (auto* key : results.get_keys()) {
@@ -263,7 +262,7 @@ int main() {
     // Output: gene1, gene2 (gene3 doesn't overlap)
 
     // Query across all chromosomes
-    auto all_results = my_grove.intersect(query);
+    auto all_results = my_grove.intersect(gdt::interval{175, 225});
     std::cout << "Total matches: " << all_results.get_keys().size() << "\n";
 
     return 0;
@@ -275,6 +274,7 @@ int main() {
 - Efficient overlap-based searching using B+ tree structure
 - Index-specific queries (single chromosome)
 - Global queries (all chromosomes)
+- Accepts temporaries and named variables (const reference parameter)
 - Returns `query_result` containing matching keys
 
 ```{toctree}

--- a/source/index.md
+++ b/source/index.md
@@ -46,8 +46,7 @@ int main() {
     }
 
     // Query for overlapping features
-    gdt::interval query{1000, 2000};
-    auto results = features.intersect(query, "chr1");
+    auto results = features.intersect(gdt::interval{1000, 2000}, "chr1");
 
     std::cout << "Found " << results.get_keys().size()
               << " overlapping features\n";


### PR DESCRIPTION
## Summary
- Update querying examples in `grove.md` and `index.md` to pass temporaries directly to `intersect()`, demonstrating the `const key_type&` signature from genogrove/genogrove#120
- Add note about const reference / temporary support in query features list

Several other pages (`serialization.md`, `key.md`, `loading_data.md`, `graph.md`, `graph_manipulation.md`) already used temporaries with `intersect()` and needed no changes.

Closes #41

## Test plan
- [x] Run `make clean && make html` and verify no Sphinx build warnings
- [x] Verify updated examples render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API usage examples to demonstrate simplified patterns for interval queries.
  * Shows how to pass interval values directly as temporary parameters without pre-declaring named variables.
  * Applies to both single-chromosome and cross-chromosome query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->