### PR TITLE
Document constexpr support for data type constructors and operators

### DIFF
--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -12,6 +12,15 @@ All data types in genogrove implement a shared interface:
 - **Serialization/Deserialization**: Binary I/O operations
 - **String representation**: Converts values to readable format
 
+Constructors, comparison operators, getters/setters, and overlap detection are `constexpr`, so they
+can be used in compile-time contexts:
+
+```cpp
+constexpr gdt::interval region{100, 200};
+static_assert(region.get_start() == 100);
+static_assert(gdt::interval::overlap(region, gdt::interval{150, 250}));
+```
+
 ## Intervals
 
 The `interval` class represents genomic regions using 0-based, half-open coordinates:


### PR DESCRIPTION
## Summary
- Add a note and compile-time example to the Common Interface section in `data_types.md` documenting that constructors, comparison operators, getters/setters, and overlap detection are `constexpr`
- API reference pages (Doxygen-generated) will pick up `constexpr` annotations automatically from the headers

Closes #42

## Test plan
- [x] Run `make clean && make html` and verify no Sphinx build warnings
- [x] Verify the constexpr example renders correctly in the Common Interface section

🤖 Generated with [Claude Code](https://claude.com/claude-code)