### PR TITLE
Update compiler support and verify legacy type removal

### DIFF
--- a/source/guide/installation.md
+++ b/source/guide/installation.md
@@ -7,9 +7,9 @@ This guide covers how to build and install genogrove for use in your projects.
 Before building genogrove, ensure you have:
 
 - **C++20 compatible compiler**
-  \- GCC 12 or newer
-  \- Clang 14 or newer
-  \- MSVC 2022 or newer
+  \- GCC 13 or newer
+  \- Clang 16 or newer
+  \- Apple Clang 15 or newer
 - **CMake 3.15 or higher**
 - **htslib** (for compressed file support)
   \- On Ubuntu/Debian: `sudo apt-get install libhts-dev`
@@ -161,10 +161,10 @@ Ensure your compiler supports C++20:
 
 ```bash
 # Check GCC version
-g++ --version  # Should be 12+
+g++ --version  # Should be 13+
 
 # Check Clang version
-clang++ --version  # Should be 14+
+clang++ --version  # Should be 16+
 ```
 
 **Build fails on older systems**
@@ -175,8 +175,8 @@ Consider using a newer compiler via devtoolset (RHEL/CentOS) or a PPA (Ubuntu):
 # Ubuntu example
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt update
-sudo apt install gcc-12 g++-12
-export CXX=g++-12
+sudo apt install gcc-13 g++-13
+export CXX=g++-13
 ```
 
 ## Next Steps

--- a/source/index.md
+++ b/source/index.md
@@ -75,7 +75,7 @@ int main() {
 
 ## Requirements
 
-- **Compiler**: C++20 compatible (GCC 12+, Clang 14+, MSVC 2022+)
+- **Compiler**: C++20 compatible (GCC 13+, Clang 16+, Apple Clang 15+)
 - **Build System**: CMake 3.15 or higher
 - **Dependencies**: htslib (for compressed file support)
 


### PR DESCRIPTION
## Summary
- Updated minimum compiler versions: GCC 12→13, Clang 14→16, added Apple Clang 15+ (genogrove/genogrove#194)
- Verified no references to `any_type`, `any_base`, or `type_registry` exist in docs (#54 is clean)

Closes #54, closes #55

## Test plan
- [ ] Run `make clean && make html` — no Sphinx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum system compiler requirements: GCC 13+, Clang 16+, and Apple Clang 15+
  * Refreshed Ubuntu installation instructions with updated toolchain steps
  * Added macOS Homebrew-specific installation guidance for required dependencies
  * Updated troubleshooting and build guidance to reflect new compiler version expectations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->