### PR TITLE
Add try-catch to reader examples

### DIFF
--- a/source/guide/examples.md
+++ b/source/guide/examples.md
@@ -21,14 +21,18 @@ int main() {
     // Read BED file
     gio::bed_reader reader("data.bed.gz");
 
-    for (const auto& entry : reader) {
-        // Insert into grove (organized by chromosome)
-        features.insert_data(
-            entry.chrom,
-            entry.interval,
-            entry.name.value_or("unnamed"),
-            gst::sorted  // BED files are typically sorted
-        );
+    try {
+        for (const auto& entry : reader) {
+            // Insert into grove (organized by chromosome)
+            features.insert_data(
+                entry.chrom,
+                entry.interval,
+                entry.name.value_or("unnamed"),
+                gst::sorted  // BED files are typically sorted
+            );
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "Error: " << e.what() << "\n";
     }
 
     // Query for overlapping features
@@ -74,31 +78,35 @@ int main() {
     // Read GFF file
     gio::gff_reader reader("annotations.gff.gz");
 
-    for (const auto& entry : reader) {
-        // Only process gene features
-        if (entry.type != "gene") continue;
+    try {
+        for (const auto& entry : reader) {
+            // Only process gene features
+            if (entry.type != "gene") continue;
 
-        // Create genomic coordinate with strand
-        gdt::genomic_coordinate coord{
-            entry.strand.value_or('.'),
-            entry.interval.get_start(),
-            entry.interval.get_end()
-        };
+            // Create genomic coordinate with strand
+            gdt::genomic_coordinate coord{
+                entry.strand.value_or('.'),
+                entry.interval.get_start(),
+                entry.interval.get_end()
+            };
 
-        // Extract annotation info
-        GeneAnnotation annot{
-            entry.get_gene_id().value_or("unknown"),
-            entry.get_gene_name().value_or("unknown"),
-            entry.type
-        };
+            // Extract annotation info
+            GeneAnnotation annot{
+                entry.get_gene_id().value_or("unknown"),
+                entry.get_gene_name().value_or("unknown"),
+                entry.type
+            };
 
-        // Insert into grove
-        annotations.insert_data(
-            entry.seqid,
-            coord,
-            annot,
-            gst::sorted
-        );
+            // Insert into grove
+            annotations.insert_data(
+                entry.seqid,
+                coord,
+                annot,
+                gst::sorted
+            );
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "Error: " << e.what() << "\n";
     }
 
     // Query for genes in a region
@@ -145,21 +153,25 @@ int main() {
     // Read GFF file
     gio::gff_reader reader("transcripts.gff");
 
-    for (const auto& entry : reader) {
-        if (entry.type != "exon") continue;
+    try {
+        for (const auto& entry : reader) {
+            if (entry.type != "exon") continue;
 
-        auto transcript_id = entry.get_transcript_id().value_or("unknown");
+            auto transcript_id = entry.get_transcript_id().value_or("unknown");
 
-        // Insert exon
-        auto* exon_key = transcripts.insert_data(
-            entry.seqid,
-            entry.interval,
-            transcript_id,
-            gst::sorted
-        );
+            // Insert exon
+            auto* exon_key = transcripts.insert_data(
+                entry.seqid,
+                entry.interval,
+                transcript_id,
+                gst::sorted
+            );
 
-        // Track exon for this transcript
-        transcript_exons[transcript_id].push_back(exon_key);
+            // Track exon for this transcript
+            transcript_exons[transcript_id].push_back(exon_key);
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "Error: " << e.what() << "\n";
     }
 
     // Build graph by connecting consecutive exons in each transcript

--- a/source/index.md
+++ b/source/index.md
@@ -23,6 +23,8 @@ Here's a complete example showing file reading, storage, and querying:
 #include <genogrove/io/bed_reader.hpp>
 #include <genogrove/structure/grove/grove.hpp>
 #include <genogrove/data_type/interval.hpp>
+#include <iostream>
+#include <stdexcept>
 
 namespace gio = genogrove::io;
 namespace gdt = genogrove::data_type;
@@ -35,14 +37,18 @@ int main() {
     // Read BED file (handles .bed.gz automatically)
     gio::bed_reader reader("genes.bed.gz");
 
-    for (const auto& entry : reader) {
-        // Insert sorted by chromosome
-        features.insert_data(
-            entry.chrom,
-            entry.interval,
-            entry.name,
-            gst::sorted  // Optimized for pre-sorted data
-        );
+    try {
+        for (const auto& entry : reader) {
+            // Insert sorted by chromosome
+            features.insert_data(
+                entry.chrom,
+                entry.interval,
+                entry.name,
+                gst::sorted  // Optimized for pre-sorted data
+            );
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "Error: " << e.what() << "\n";
     }
 
     // Query for overlapping features


### PR DESCRIPTION
## Summary
- Wrapped reader iteration in try-catch in `index.md` quick start and all three `examples.md` examples
- Matches the error handling pattern established in `io.md` and `loading_data.md`

Closes #38

## Test plan
- [x] Run `make clean && make html` — no Sphinx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced code examples with comprehensive error handling, including exception management and clear error messaging for improved robustness.
  * Updated documentation to demonstrate best practices for handling runtime errors during file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->