### PR TITLE
Update docs for pairwise aggregate, string_view, and concept constraints

### DIFF
--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -46,11 +46,8 @@ int main() {
         std::cout << "iv3 comes before iv1\n";
     }
 
-    // Aggregate multiple intervals
-    std::vector<gdt::interval> intervals = {
-        {100, 200}, {150, 250}, {300, 400}
-    };
-    auto merged = gdt::interval::aggregate(intervals);
+    // Aggregate two intervals into one
+    auto merged = gdt::interval::aggregate(iv1, iv2);
 
     // String representation
     std::cout << iv1.to_string() << "\n";  // "[100, 200)"
@@ -62,7 +59,7 @@ int main() {
 **Interval Methods:**
 
 - `overlap(a, b)` - Static method to check overlap
-- `aggregate(intervals)` - Merge overlapping intervals
+- `aggregate(a, b)` - Merge two intervals into their bounding interval
 - Comparison: `<`, `>`, `==`
 - `get_start()`, `set_start()`, `get_end()`, `set_end()`
 - `to_string()` - String representation
@@ -161,9 +158,8 @@ int main() {
         std::cout << "Values are equal\n";
     }
 
-    // Aggregation returns the maximum value
-    std::vector<gdt::numeric> values = {{50}, {100}, {75}};
-    auto max_val = gdt::numeric::aggregate(values);  // Returns 100
+    // Aggregation returns the maximum of two values
+    auto max_val = gdt::numeric::aggregate(n1, n2);  // Returns 200
 
     return 0;
 }

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -25,7 +25,7 @@ You can use any custom type as a key in the grove, as long as it satisfies the `
 // Required operations for key_type_base concept:
 // 1. Comparison operators: <, >, ==
 // 2. Static overlap detection: overlap(a, b) -> bool
-// 3. Static aggregation: aggregate(vector<T>) -> T
+// 3. Static pairwise aggregation: aggregate(a, b) -> T
 // 4. String representation: to_string() -> string
 ```
 
@@ -57,16 +57,9 @@ struct CustomInterval {
         return !(a.end <= b.start || b.end <= a.start);
     }
 
-    // Static aggregate method
-    static CustomInterval aggregate(const std::vector<CustomInterval>& intervals) {
-        if (intervals.empty()) return {0, 0, 0};
-        size_t min_start = intervals[0].start;
-        size_t max_end = intervals[0].end;
-        for (const auto& iv : intervals) {
-            min_start = std::min(min_start, iv.start);
-            max_end = std::max(max_end, iv.end);
-        }
-        return {min_start, max_end, 0};
+    // Static pairwise aggregate method
+    static CustomInterval aggregate(const CustomInterval& a, const CustomInterval& b) {
+        return {std::min(a.start, b.start), std::max(a.end, b.end), 0};
     }
 
     // String representation
@@ -272,10 +265,18 @@ int main() {
 **Query Features:**
 
 - Efficient overlap-based searching using B+ tree structure
-- Index-specific queries (single chromosome)
+- Index-specific queries (single chromosome) — `index` parameter accepts `std::string_view`
 - Global queries (all chromosomes)
 - Accepts temporaries and named variables (const reference parameter)
 - Returns `query_result` containing matching keys
+
+**Concept Constraints:**
+
+The grove uses C++20 concepts to provide clear compile-time errors:
+
+- `link_if(keys, predicate)` requires `std::invocable<Predicate, key*, key*>`
+- `get_neighbors_if(source, predicate)` requires `std::predicate<Predicate, const edge_data_type&>`
+- Bulk insert `Container` parameters require `std::ranges::input_range<Container>`
 
 ```{toctree}
 :maxdepth: 1

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -237,7 +237,7 @@ int main() {
 - `score` (std::optional\<double>): Score value (`std::nullopt` when `.` in file)
 - `strand` (std::optional\<char>): Strand (+, -, ., or ?)
 - `phase` (std::optional\<int>): Phase for CDS features (0, 1, or 2)
-- `attributes` (std::map\<std::string, std::string>): Key-value pairs from column 9
+- `attributes` (std::map\<std::string, std::string, std::less\<>>): Key-value pairs from column 9 (transparent comparator enables `string_view` lookups)
 - `format` (gff_format): Detected format — `gff_format::GFF3`, `gff_format::GTF`, or `gff_format::UNKNOWN`
 
 ### Attribute Access
@@ -250,7 +250,7 @@ Some helpers try multiple attribute keys to work across GFF3 and GTF conventions
 - `get_exon_number()` — parses `exon_number` as `int`
 - `get_gene_name()` — tries `gene_name`, then falls back to GFF3's `Name`
 - `get_gene_biotype()` — tries `gene_biotype`, `gene_type`, then `biotype`
-- `get_attribute(key)` — generic getter for any attribute key
+- `get_attribute(key)` — generic getter for any attribute key (accepts `std::string_view`)
 
 You can also access the attributes map directly:
 


### PR DESCRIPTION
## Summary
- Updated `aggregate()` from `vector<T>` to pairwise `(const T&, const T&)` signature (#58, supersedes span part of #53)
- Updated `key_type_base` concept and custom key type example
- Documented concept constraints: `link_if`, `get_neighbors_if`, bulk insert containers
- Noted `string_view` adoption on `intersect()` index param and `get_attribute()`
- Updated `gff_entry::attributes` map to use transparent comparator (`std::less<>`)

Closes #53, closes #58

## Test plan
- [ ] Run `make clean && make html` — no Sphinx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)