### PR TITLE
Update docs for I/O decoupling and coordinate semantics

### DIFF
--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -23,7 +23,7 @@ static_assert(gdt::interval::overlap(region, gdt::interval{150, 250}));
 
 ## Intervals
 
-The `interval` class represents genomic regions using 0-based, half-open coordinates:
+The `interval` class represents genomic regions using closed `[start, end]` coordinates (both endpoints inclusive):
 
 ```cpp
 #include <genogrove/data_type/interval.hpp>
@@ -32,8 +32,8 @@ namespace gdt = genogrove::data_type;
 
 int main() {
     // Create intervals
-    gdt::interval iv1{100, 200};  // [100, 200)
-    gdt::interval iv2{150, 250};  // [150, 250)
+    gdt::interval iv1{100, 200};  // [100, 200]
+    gdt::interval iv2{150, 250};  // [150, 250]
 
     // Check for overlap
     if (gdt::interval::overlap(iv1, iv2)) {
@@ -53,7 +53,7 @@ int main() {
     auto merged = gdt::interval::aggregate(intervals);
 
     // String representation
-    std::cout << iv1.to_string() << "\n";  // "[100, 200)"
+    std::cout << iv1.to_string() << "\n";  // "[100, 200]"
 
     return 0;
 }

--- a/source/guide/examples.md
+++ b/source/guide/examples.md
@@ -24,9 +24,10 @@ int main() {
     try {
         for (const auto& entry : reader) {
             // Insert into grove (organized by chromosome)
+            // Convert half-open [start, end) to closed [start, end]
             features.insert_data(
                 entry.chrom,
-                entry.interval,
+                gdt::interval(entry.start, entry.end - 1),
                 entry.name.value_or("unnamed"),
                 gst::sorted  // BED files are typically sorted
             );
@@ -83,11 +84,11 @@ int main() {
             // Only process gene features
             if (entry.type != "gene") continue;
 
-            // Create genomic coordinate with strand
+            // Create genomic coordinate with strand (convert half-open to closed)
             gdt::genomic_coordinate coord{
                 entry.strand.value_or('.'),
-                entry.interval.get_start(),
-                entry.interval.get_end()
+                entry.start,
+                entry.end - 1
             };
 
             // Extract annotation info
@@ -159,10 +160,10 @@ int main() {
 
             auto transcript_id = entry.get_transcript_id().value_or("unknown");
 
-            // Insert exon
+            // Insert exon (convert half-open to closed)
             auto* exon_key = transcripts.insert_data(
                 entry.seqid,
-                entry.interval,
+                gdt::interval(entry.start, entry.end - 1),
                 transcript_id,
                 gst::sorted
             );

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -12,7 +12,7 @@ Beyond the core data structure covered on this page, the grove also supports:
 
 The grove is highly flexible and can work with any key type that satisfies the `key_type_base` concept. Genogrove provides four built-in key types:
 
-- `interval` - Basic genomic intervals (0-based, half-open)
+- `interval` - Basic genomic intervals (closed `[start, end]`)
 - `genomic_coordinate` - Intervals with strand information
 - `numeric` - Single numerical value
 - `kmer` - Single k-mer value

--- a/source/guide/grove/loading_data.md
+++ b/source/guide/grove/loading_data.md
@@ -24,7 +24,9 @@ int main() {
     try {
         for (const auto& entry : reader) {
             // BED files are typically sorted by position
-            my_grove.insert_data(entry.chrom, entry.interval,
+            // Convert half-open [start, end) to closed [start, end]
+            my_grove.insert_data(entry.chrom,
+                                gdt::interval(entry.start, entry.end - 1),
                                 entry.name.value_or("unknown"),
                                 gst::sorted);
         }
@@ -66,7 +68,9 @@ int main() {
     gio::bed_reader reader("large_dataset.bed.gz");
     try {
         for (const auto& entry : reader) {
-            data[entry.chrom].emplace_back(entry.interval, entry.name.value_or("unknown"));
+            data[entry.chrom].emplace_back(
+                gdt::interval(entry.start, entry.end - 1),
+                entry.name.value_or("unknown"));
         }
     } catch (const std::runtime_error& e) {
         std::cerr << "Error: " << e.what() << "\n";
@@ -100,7 +104,8 @@ int main() {
     gio::gff_reader reader("annotations.gff.gz");
     try {
         for (const auto& entry : reader) {
-            my_grove.insert_data(entry.seqid, entry.interval,
+            my_grove.insert_data(entry.seqid,
+                                gdt::interval(entry.start, entry.end - 1),
                                 entry.get_gene_id().value_or(entry.type),
                                 gst::sorted);
         }
@@ -135,7 +140,8 @@ int main() {
 
     try {
         for (const auto& entry : reader) {
-            my_grove.insert_data(entry.chrom, entry.interval,
+            my_grove.insert_data(entry.chrom,
+                                 gdt::interval(entry.start, entry.end - 1),
                                  entry.qname, gst::sorted);
         }
     } catch (const std::runtime_error& e) {
@@ -150,6 +156,7 @@ int main() {
 
 ## Key Points
 
+- Readers produce 0-based half-open `[start, end)` coordinates; the grove uses closed `[start, end]` — subtract 1 from `end` when constructing `gdt::interval`
 - File readers handle decompression automatically
 - For small files, use incremental insertion with `sorted` tag
 - For large files (>10K intervals), collect data and use bulk insertion with the `sorted` tag

--- a/source/guide/installation.md
+++ b/source/guide/installation.md
@@ -127,7 +127,7 @@ Compile and run:
 ```bash
 g++ -std=c++20 test.cpp -o test
 ./test
-# Output: Genogrove is working! Interval: [100, 200)
+# Output: Genogrove is working! Interval: [100, 200]
 ```
 
 ## Development Build

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -113,6 +113,25 @@ if (!reader.get_error_message().empty()) {
 }
 ```
 
+## Coordinate Semantics
+
+Readers and the grove use different coordinate conventions:
+
+- **Readers** (`bed_reader`, `gff_reader`, `bam_reader`) produce **0-based half-open** `[start, end)` coordinates — matching their respective file format conventions.
+- **Grove** (`gdt::interval`) uses **closed** `[start, end]` coordinates — where `start` and `end` are both inclusive.
+
+When inserting reader entries into a grove, convert from half-open to closed:
+
+```cpp
+for (const auto& entry : reader) {
+    grove.insert_data(entry.chrom,
+                      gdt::interval(entry.start, entry.end - 1),
+                      data);
+}
+```
+
+The `- 1` on `end` converts from half-open to closed. When outputting results, `entry.start` and `entry.end` retain the original format-native (half-open) values — no conversion needed for writing back to BED/GFF/BAM.
+
 ## BED Files
 
 BED files store genomic intervals with optional metadata. The `bed_reader` provides iterator-based access:
@@ -130,8 +149,8 @@ int main() {
     try {
         for (const auto& entry : reader) {
             std::cout << "Chromosome: " << entry.chrom << "\n"
-                      << "Start: " << entry.interval.get_start() << "\n"
-                      << "End: " << entry.interval.get_end() << "\n";
+                      << "Start: " << entry.start << "\n"
+                      << "End: " << entry.end << "\n";
 
             // Optional fields (if present in file)
             if (entry.name) {
@@ -160,8 +179,8 @@ gio::bed_reader reader("mixed.bed");
 for (const auto& entry : reader) {
     // Always present (BED3)
     std::cout << entry.chrom << "\t"
-              << entry.interval.get_start() << "\t"
-              << entry.interval.get_end();
+              << entry.start << "\t"
+              << entry.end;
 
     // Only set on BED6+ lines
     if (entry.name)   std::cout << "\t" << *entry.name;
@@ -178,7 +197,8 @@ for (const auto& entry : reader) {
 ### BED Entry Fields
 
 - `chrom` (std::string): Chromosome name
-- `interval` (gdt::interval): Genomic interval (0-based, half-open)
+- `start` (size_t): Start position (0-based, half-open)
+- `end` (size_t): End position (0-based, half-open)
 - `name` (std::optional\<std::string>): Feature name
 - `score` (std::optional\<int>): Score value
 - `strand` (std::optional\<char>): Strand (+/-)
@@ -190,7 +210,7 @@ for (const auto& entry : reader) {
 
 GFF3 and GTF files contain gene annotations. The `gff_reader` auto-detects the format variant
 by inspecting the attribute column (GFF3 uses `key=value`, GTF uses `key "value"`).
-Coordinates are 1-based inclusive in the file and converted to 0-based half-open intervals.
+Coordinates are 1-based inclusive in the file and converted to 0-based half-open `[start, end)` values.
 
 ```cpp
 #include <genogrove/io/gff_reader.hpp>
@@ -205,8 +225,8 @@ int main() {
         for (const auto& entry : reader) {
             std::cout << "Sequence: " << entry.seqid << "\n"
                       << "Type: " << entry.type << "\n"
-                      << "Start: " << entry.interval.get_start() << "\n"
-                      << "End: " << entry.interval.get_end() << "\n";
+                      << "Start: " << entry.start << "\n"
+                      << "End: " << entry.end << "\n";
 
             // Access attributes (column 9)
             if (auto gene_id = entry.get_gene_id()) {
@@ -233,7 +253,8 @@ int main() {
 - `seqid` (std::string): Chromosome/contig name
 - `source` (std::string): Source of the feature
 - `type` (std::string): Feature type (gene, exon, CDS, etc.)
-- `interval` (gdt::interval): Genomic interval (0-based, half-open, converted from 1-based inclusive)
+- `start` (size_t): Start position (0-based, half-open, converted from 1-based inclusive)
+- `end` (size_t): End position (0-based, half-open, converted from 1-based inclusive)
 - `score` (std::optional\<double>): Score value (`std::nullopt` when `.` in file)
 - `strand` (std::optional\<char>): Strand (+, -, ., or ?)
 - `phase` (std::optional\<int>): Phase for CDS features (0, 1, or 2)
@@ -279,7 +300,7 @@ If validation fails, `read_next()` throws `std::runtime_error` (or skips the lin
 
 BAM, SAM, and CRAM files store sequence alignments. The `bam_reader` auto-detects the format and handles
 decompression via htslib. SAM uses 1-based positions (POS); these are converted to 0-based half-open
-intervals using the CIGAR string to compute the aligned reference length.
+`[start, end)` values using the CIGAR string to compute the aligned reference length.
 
 ```cpp
 #include <genogrove/io/bam_reader.hpp>
@@ -294,8 +315,8 @@ int main() {
         for (const auto& entry : reader) {
             std::cout << "Read: " << entry.qname << "\n"
                       << "Chrom: " << entry.chrom << "\n"
-                      << "Start: " << entry.interval.get_start() << "\n"
-                      << "End: " << entry.interval.get_end() << "\n"
+                      << "Start: " << entry.start << "\n"
+                      << "End: " << entry.end << "\n"
                       << "Strand: " << entry.get_strand() << "\n"
                       << "MAPQ: " << static_cast<int>(entry.mapq) << "\n"
                       << "CIGAR: " << entry.cigar_string_repr() << "\n";
@@ -350,7 +371,8 @@ gio::bam_reader reader5("reads.bam", opts);
 
 - `qname` (std::string): Read name
 - `chrom` (std::string): Reference sequence name
-- `interval` (gdt::interval): Genomic interval (0-based, half-open, computed from POS + CIGAR)
+- `start` (size_t): Start position (0-based, half-open, computed from POS)
+- `end` (size_t): End position (0-based, half-open, computed from POS + CIGAR)
 - `flags` (alignment_flags): Bitwise flags with convenience methods (`is_paired()`, `is_reverse()`, `is_duplicate()`, etc.)
 - `mapq` (uint8_t): Mapping quality
 - `cigar` (cigar_string): CIGAR operations as a `std::vector<cigar_element>`

--- a/source/index.md
+++ b/source/index.md
@@ -40,9 +40,10 @@ int main() {
     try {
         for (const auto& entry : reader) {
             // Insert sorted by chromosome
+            // Convert half-open [start, end) to closed [start, end]
             features.insert_data(
                 entry.chrom,
-                entry.interval,
+                gdt::interval(entry.start, entry.end - 1),
                 entry.name,
                 gst::sorted  // Optimized for pre-sorted data
             );


### PR DESCRIPTION
## Summary
- Entry structs (`bed_entry`, `gff_entry`, `sam_entry`) now have `start`/`end` fields instead of `gdt::interval` (genogrove/genogrove#163)
- `gdt::interval` uses closed `[start, end]` coordinates; readers use half-open `[start, end)`
- Added Coordinate Semantics section to I/O guide explaining the conversion
- Updated all insertion examples to show `end - 1` conversion
- Updated struct field documentation across BED, GFF, and BAM sections

Closes #52

## Test plan
- [ ] Run `make clean && make html` — no Sphinx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coordinate system documentation to clarify handling of interval representations across data loading workflows.
  * Added new Coordinate Semantics section explaining data format conversions.

* **Improvements**
  * Entry data structures now expose `start` and `end` fields instead of interval objects for improved clarity.
  * Coordinate conversion automatically handled when loading genomic data from various formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->