### PR TITLE
Document grove constructor validation, fill_factor, and deserialization errors

### DIFF
--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -92,8 +92,9 @@ namespace gdt = genogrove::data_type;
 namespace gst = genogrove::structure;
 
 int main() {
-    // grove<key_type, data_type, edge_data_type>
+    // grove<key_type, data_type, edge_data_type>(order, fill_factor)
     // Order determines max keys per node (higher = more cache-friendly)
+    // Order must be >= 2 (throws std::out_of_range otherwise)
 
     // Using built-in interval type
     gst::grove<gdt::interval, std::string> grove1(100);
@@ -101,8 +102,8 @@ int main() {
     // Using genomic_coordinate (with strand)
     gst::grove<gdt::genomic_coordinate, std::string> grove2(100);
 
-    // Using custom key type
-    gst::grove<CustomInterval, std::string> grove3(100);
+    // With custom fill factor for sorted insertion splits (default: 1.0)
+    gst::grove<gdt::interval, std::string> grove3(100, 0.7f);
 
     return 0;
 }
@@ -113,6 +114,11 @@ int main() {
 - `key_type`: Type satisfying `key_type_base` concept (interval, genomic_coordinate, or custom)
 - `data_type`: Associated data type (default: void for no data)
 - `edge_data_type`: Edge metadata for graph overlay (default: void)
+
+**Constructor Parameters:**
+
+- `order` (int): Maximum keys per node. Must be >= 2; throws `std::out_of_range` otherwise.
+- `fill_factor` (float, default `1.0f`): Controls how full the left node is after a sorted-path split. Must be in `[0.5, 1.0]`. At 1.0, leaves are packed fully (~100%). At 0.5, classic midpoint split. Use `get_fill_factor()` / `set_fill_factor()` to inspect or change after construction.
 
 ## Inserting Data
 

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -179,6 +179,8 @@ struct genogrove::data_type::serialization_traits<ThirdPartyType> {
 
 ## Important Notes
 
-- All `deserialize` methods throw `std::runtime_error` on stream read failures
+- All `deserialize` methods (`node::deserialize`, `grove::deserialize`, `data_registry::deserialize`, `serialization_traits<std::string>::deserialize`) throw `std::runtime_error` on corrupt or truncated streams
+- `node::deserialize` additionally validates B+ tree invariants (num_keys < order, num_children <= order)
+- The grove's `fill_factor` is included in the serialized format and restored on deserialize
 - Graph edges are **not** serialized — you must rebuild the graph overlay after deserialization
 - All `deserialize` methods are marked `[[nodiscard]]` to prevent accidentally discarding the result


### PR DESCRIPTION
## Summary
- Documented constructor `order >= 2` validation with `std::out_of_range` (#56)
- Added `fill_factor` constructor parameter, getter/setter, and valid range docs (#59)
- Updated serialization guide with deserialization error handling details (#56)
- Noted fill_factor persistence in serialized format (#59)
- #57 (transparent hashing) affects `get_root_nodes`/`set_root_nodes` which are not in the user guide — no doc changes needed

Closes #56, closes #57, closes #59

## Test plan
- [ ] Run `make clean && make html` — no Sphinx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grove constructor now accepts an optional fill_factor parameter (default 1.0) alongside the existing order parameter.

* **Documentation**
  * Enhanced constructor documentation with parameter constraints and usage guidelines.
  * Updated serialization documentation clarifying fill_factor handling during serialization and deserialization.
  * Expanded error handling documentation for deserialization methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->