### PR TITLE
Fix docs-sync: overlaps rename, version bump, zlib, compiler versions, Doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Genogrove Documentation
 
 [![Read the Docs — Genogrove documentation](https://img.shields.io/readthedocs/genogrove)](https://genogrove.readthedocs.io/)
-[![Genogrove version](https://img.shields.io/badge/genogrove-v0.16.0-green.svg)](https://github.com/genogrove/genogrove)
+[![Genogrove version](https://img.shields.io/badge/genogrove-v0.17.0-green.svg)](https://github.com/genogrove/genogrove)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Sphinx](https://img.shields.io/badge/built%20with-Sphinx-blue.svg)](https://www.sphinx-doc.org/)
 [![MyST](https://img.shields.io/badge/markup-MyST%20Markdown-purple.svg)](https://myst-parser.readthedocs.io/)

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,7 +10,7 @@ import os
 project = "genogrove"
 copyright = "2026, Richard. A. Schaefer"
 author = "Richard. A. Schaefer"
-release = "0.16.0"
+release = "0.17.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -18,7 +18,7 @@ can be used in compile-time contexts:
 ```cpp
 constexpr gdt::interval region{100, 200};
 static_assert(region.get_start() == 100);
-static_assert(gdt::interval::overlap(region, gdt::interval{150, 250}));
+static_assert(gdt::interval::overlaps(region, gdt::interval{150, 250}));
 ```
 
 ## Intervals
@@ -36,7 +36,7 @@ int main() {
     gdt::interval iv2{150, 250};  // [150, 250]
 
     // Check for overlap
-    if (gdt::interval::overlap(iv1, iv2)) {
+    if (gdt::interval::overlaps(iv1, iv2)) {
         std::cout << "Intervals overlap\n";
     }
 
@@ -58,7 +58,7 @@ int main() {
 
 **Interval Methods:**
 
-- `overlap(a, b)` - Static method to check overlap
+- `overlaps(a, b)` - Static method to check overlap
 - `aggregate(a, b)` - Merge two intervals into their bounding interval
 - Comparison: `<`, `>`, `==`
 - `get_start()`, `set_start()`, `get_end()`, `set_end()`
@@ -86,7 +86,7 @@ int main() {
     coord.set_strand('-');
 
     // All interval methods are available
-    if (gdt::genomic_coordinate::overlap(coord, other_coord)) {
+    if (gdt::genomic_coordinate::overlaps(coord, other_coord)) {
         std::cout << "Coordinates overlap\n";
     }
 
@@ -154,7 +154,7 @@ int main() {
 
     // Overlap occurs only when values are exactly equal
     gdt::numeric n3{100};
-    if (gdt::numeric::overlap(n1, n3)) {
+    if (gdt::numeric::overlaps(n1, n3)) {
         std::cout << "Values are equal\n";
     }
 
@@ -192,7 +192,7 @@ int main() {
 
     // Overlap requires exact sequence match
     gdt::kmer k3{"ACGT"};
-    if (gdt::kmer::overlap(k1, k3)) {
+    if (gdt::kmer::overlaps(k1, k3)) {
         std::cout << "K-mers are identical\n";
     }
 

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -24,7 +24,7 @@ You can use any custom type as a key in the grove, as long as it satisfies the `
 ```cpp
 // Required operations for key_type_base concept:
 // 1. Comparison operators: <, >, ==
-// 2. Static overlap detection: overlap(a, b) -> bool
+// 2. Static overlap detection: overlaps(a, b) -> bool
 // 3. Static pairwise aggregation: aggregate(a, b) -> T
 // 4. String representation: to_string() -> string
 ```
@@ -53,7 +53,7 @@ struct CustomInterval {
     }
 
     // Static overlap method
-    static bool overlap(const CustomInterval& a, const CustomInterval& b) {
+    static bool overlaps(const CustomInterval& a, const CustomInterval& b) {
         return !(a.end <= b.start || b.end <= a.start);
     }
 

--- a/source/guide/performance.md
+++ b/source/guide/performance.md
@@ -174,7 +174,7 @@ Save and load grove structures for faster startup:
     my_grove.serialize(out);
 }
 
-// Load grove from disk (implementation in progress)
+// Load grove from disk
 {
     std::ifstream in("grove_data.bin", std::ios::binary);
     auto loaded_grove = gst::grove<gdt::interval, std::string>::deserialize(in);

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -41,7 +41,9 @@ Always open streams with `std::ios::binary` to avoid platform-specific newline t
 
 ## How It Works
 
-The grove serializes its complete B+ tree structure to a stream in a depth-first traversal:
+The grove serializes its complete B+ tree structure using **zlib compression**. The output is a
+compressed binary stream (not raw bytes), so files are compact but not directly inspectable with
+hex editors. Internally the data is written in a depth-first traversal:
 
 1. Tree order and number of indices (chromosomes)
 2. For each index: the index name followed by the full tree (nodes, keys, and associated data)

--- a/source/reference/cpp/data_type.md
+++ b/source/reference/cpp/data_type.md
@@ -2,6 +2,17 @@
 
 The `genogrove::data_type` namespace contains genomic data type definitions and utilities.
 
+## key_type_base Concept
+
+The `key_type_base` concept defines the requirements for custom key types used with the grove:
+
+- `a < b`, `a > b`, `a == b` — Comparison operators
+- `T::overlaps(a, b)` — Static overlap detection returning `bool`
+- `T::aggregate(a, b)` — Static pairwise aggregation returning `T`
+- `a.to_string()` — String representation
+
+All built-in key types (`interval`, `genomic_coordinate`, `numeric`, `kmer`) satisfy this concept.
+
 ## interval
 
 ```{eval-rst}

--- a/source/reference/cpp/structure.md
+++ b/source/reference/cpp/structure.md
@@ -2,6 +2,32 @@
 
 The `genogrove::structure` namespace contains core data structures for genomic data storage and querying.
 
+## Tag Types
+
+### sorted_t
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::structure::sorted_t
+   :members:
+   :undoc-members:
+```
+
+### bulk_t
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::structure::bulk_t
+   :members:
+   :undoc-members:
+```
+
+## string_hash
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::structure::string_hash
+   :members:
+   :undoc-members:
+```
+
 ## grove
 
 ```{eval-rst}

--- a/source/user_guide.md
+++ b/source/user_guide.md
@@ -7,7 +7,7 @@ This user guide provides comprehensive coverage of genogrove's functionality, fr
 Before starting, ensure you have:
 
 - Installed genogrove (see {doc}`index` for installation instructions)
-- A C++20 compatible compiler (GCC 12+, Clang 14+)
+- A C++20 compatible compiler (GCC 13+, Clang 16+, Apple Clang 15+)
 - Basic familiarity with genomic file formats (BED, GFF/GTF)
 
 ## Guide Contents


### PR DESCRIPTION
## Summary
- **#65**: Renamed `overlap()` → `overlaps()` in all code examples and method lists (`data_types.md`, `grove.md`)
- **#66**: Bumped version to 0.17.0 in `conf.py` and README badge
- **#67**: Documented zlib compression in serialization guide; removed stale "implementation in progress" comment
- **#68**: Fixed compiler versions in `user_guide.md` (GCC 13+, Clang 16+, Apple Clang 15+)
- **#69**: Added Doxygen directives for `sorted_t`, `bulk_t`, `string_hash`; documented `key_type_base` concept

Closes #65, closes #66, closes #67, closes #68, closes #69

## Test plan
- [ ] Run `make clean && make html` — no Sphinx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.17.0

* **API Changes**
  * Renamed overlap() to overlaps() across interval, genomic_coordinate, numeric, and kmer data types

* **Documentation**
  * Added concept documentation for custom key types
  * Added tag-related structures documentation
  * Updated serialization documentation with compression details
  * Updated C++ compiler requirements to GCC 13+, Clang 16+, and Apple Clang 15+

* **Chores**
  * Version bumped to 0.17.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->