### PR TITLE
Document get_error_message() contract for IO readers

### DIFF
--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -90,7 +90,7 @@ This pattern applies to all readers (`bed_reader`, `gff_reader`, `bam_reader`).
 ### Lenient Mode
 
 To skip malformed records instead of throwing, enable lenient mode via the reader's options struct.
-Skipped errors are accumulated in `get_error_message()`:
+Use `get_error_message()` to check for errors on individual records:
 
 ```cpp
 namespace gio = genogrove::io;
@@ -107,9 +107,25 @@ gio::bed_reader reader("data.bed", gio::bed_reader_options{.skip_invalid_lines =
 for (const auto& entry : reader) {
     // process entries — malformed lines are silently skipped
 }
+```
 
-if (!reader.get_error_message().empty()) {
-    std::cerr << "Warning: " << reader.get_error_message() << "\n";
+### Error Message Lifecycle
+
+`get_error_message()` reflects the **most recently attempted record** only — it is cleared at the
+start of each iteration. It does not accumulate errors across records.
+
+- **During iteration**: contains the error from the last skipped record (if any), or is empty if the
+  last record was valid.
+- **After iteration completes**: empty, because the final read was EOF (no error).
+
+To log every skipped record, check `get_error_message()` inside the loop:
+
+```cpp
+for (const auto& entry : reader) {
+    if (!reader.get_error_message().empty()) {
+        std::cerr << "Skipped: " << reader.get_error_message() << "\n";
+    }
+    // process valid entry...
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update lenient mode description: `get_error_message()` reflects only the most recent record, not accumulated errors
- Add **Error Message Lifecycle** section documenting the per-iteration clearing behavior
- Provide correct usage pattern for logging skipped records inside the loop

Closes #76

## Test plan
- [x] Run `make clean && make html` and verify no Sphinx build warnings
- [ ] Review rendered Error Message Lifecycle section in IO guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified lenient-mode documentation on error message behavior and updated examples to demonstrate proper usage during iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->