### PR TITLE
Fix wrong parameter types in graph function signatures

### DIFF
--- a/source/guide/grove/graph.md
+++ b/source/guide/grove/graph.md
@@ -34,10 +34,11 @@ The `add_edge` function creates a directed connection from one key to another in
 
 ```cpp
 // Without metadata
-void add_edge(const key_type* source, const key_type* target)
+void add_edge(gdt::key<key_type, data_type>* source, gdt::key<key_type, data_type>* target)
 
 // With metadata
-void add_edge(const key_type* source, const key_type* target, const EdgeMetadata& metadata)
+void add_edge(gdt::key<key_type, data_type>* source, gdt::key<key_type, data_type>* target,
+              EdgeMetadata&& metadata)
 ```
 
 **Parameters:**
@@ -208,11 +209,11 @@ satisfy certain criteria (e.g., belonging to the same transcript, within a dista
 ```cpp
 // Without metadata: predicate returns bool
 template<typename Predicate>
-void link_if(const std::vector<key_type*>& keys, Predicate predicate)
+void link_if(const std::vector<gdt::key<key_type, data_type>*>& keys, Predicate predicate)
 
 // With metadata: predicate returns std::optional<EdgeMetadata>
 template<typename Predicate>
-void link_if(const std::vector<key_type*>& keys, Predicate predicate)
+void link_if(const std::vector<gdt::key<key_type, data_type>*>& keys, Predicate predicate)
 ```
 
 **Parameters:**
@@ -333,10 +334,10 @@ The `add_external_key` function creates keys that:
 
 ```cpp
 // With associated data
-key_type* add_external_key(key_type key_value, data_type data_value)
+gdt::key<key_type, data_type>* add_external_key(key_type key_value, data_type data_value)
 
 // Without associated data (when data_type is void)
-key_type* add_external_key(key_type key_value)
+gdt::key<key_type, data_type>* add_external_key(key_type key_value)
 ```
 
 **Parameters:**

--- a/source/guide/grove/graph_manipulation.md
+++ b/source/guide/grove/graph_manipulation.md
@@ -11,7 +11,7 @@ The `has_edge` function checks whether a directed edge exists from a source key 
 **Function Signature:**
 
 ```cpp
-bool has_edge(const key_type* source, const key_type* target) const
+bool has_edge(gdt::key<key_type, data_type>* source, gdt::key<key_type, data_type>* target) const
 ```
 
 **Parameters:**
@@ -58,7 +58,7 @@ The `get_edges` function retrieves the metadata for all outgoing edges from a so
 
 ```cpp
 template<typename M = edge_data_type>
-std::vector<M> get_edges(source) const
+std::vector<M> get_edges(gdt::key<key_type, data_type>* source) const
     requires (!std::is_void_v<edge_data_type>)
 ```
 
@@ -114,7 +114,7 @@ The `get_edge_list` function retrieves all outgoing edges from a source key as `
 **Function Signature:**
 
 ```cpp
-const std::vector<edge>& get_edge_list(source) const
+const std::vector<edge>& get_edge_list(gdt::key<key_type, data_type>* source) const
 ```
 
 **Parameters:**
@@ -163,7 +163,7 @@ The `get_neighbors` function returns all target keys that are connected from a s
 **Function Signature:**
 
 ```cpp
-std::vector<const key_type*> get_neighbors(const key_type* source) const
+std::vector<gdt::key<key_type, data_type>*> get_neighbors(gdt::key<key_type, data_type>* source) const
 ```
 
 **Parameters:**
@@ -240,7 +240,7 @@ The `get_neighbors_if` function returns only neighbors whose edges satisfy a giv
 
 ```cpp
 template<typename Predicate>
-std::vector<const key_type*> get_neighbors_if(const key_type* source, Predicate pred) const
+std::vector<gdt::key<key_type, data_type>*> get_neighbors_if(gdt::key<key_type, data_type>* source, Predicate pred) const
 ```
 
 **Parameters:**
@@ -311,7 +311,7 @@ The `remove_edge` function removes a specific directed edge from the graph. The 
 **Function Signature:**
 
 ```cpp
-bool remove_edge(source, target)
+bool remove_edge(gdt::key<key_type, data_type>* source, gdt::key<key_type, data_type>* target)
 ```
 
 **Parameters:**
@@ -378,7 +378,7 @@ The `out_degree` function returns the number of outgoing edges from a specific k
 **Function Signature:**
 
 ```cpp
-size_t out_degree(const key_type* source) const
+size_t out_degree(gdt::key<key_type, data_type>* source) const
 ```
 
 **Parameters:**
@@ -413,10 +413,10 @@ std::cout << "TF1 regulates " << grove.out_degree(tf) << " genes\n";
 gst::grove<gdt::interval, std::string, void> network(100);
 
 // Build gene regulatory network...
-std::vector<const key_type*> all_genes = { /* ... */ };
+std::vector<gdt::key<gdt::interval, std::string>*> all_genes = { /* ... */ };
 
 // Find genes with high out-degree (hub regulators)
-std::vector<const key_type*> hubs;
+std::vector<gdt::key<gdt::interval, std::string>*> hubs;
 for (auto* gene : all_genes) {
     if (network.out_degree(gene) >= 10) {
         hubs.push_back(gene);


### PR DESCRIPTION
## Summary
- Replace incorrect `key_type*` with `gdt::key<key_type, data_type>*` in all function signature blocks in `graph.md` and `graph_manipulation.md`
- Fix missing parameter types in `get_edges()`, `get_edge_list()`, and `remove_edge()` signatures
- Fix code example using `const key_type*` vector type with concrete `gdt::key<gdt::interval, std::string>*`

Closes #80

## Test plan
- [ ] Run `make clean && make html` and verify no Sphinx build warnings
- [ ] Review all function signature blocks in graph.md and graph_manipulation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated graph manipulation API documentation with refined type specifications across edge and node operations for improved type consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->