### PR TITLE
Update docs for upstream API changes

### DIFF
--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -58,10 +58,11 @@ int main() {
 
 **Interval Methods:**
 
+- `INVALID_POSITION` — Named constant (`std::numeric_limits<size_t>::max()`) used as the sentinel for default-constructed (uninitialized) intervals. Use this instead of `std::string::npos` when checking for uninitialized state.
 - `overlaps(a, b)` - Static method to check overlap
 - `aggregate(a, b)` - Merge two intervals into their bounding interval
 - Comparison: `<`, `>`, `==`
-- `get_start()`, `set_start()`, `get_end()`, `set_end()`
+- `get_start()`, `get_end()`, `set_range(start, end)` — validates both positions atomically
 - `to_string()` - String representation
 
 ## Genomic Coordinates
@@ -82,8 +83,11 @@ int main() {
     size_t start = coord.get_start();
     size_t end = coord.get_end();
 
-    // Modify strand
+    // Modify strand (validates: must be '+', '-', or '.')
     coord.set_strand('-');
+
+    // Modify both positions atomically
+    coord.set_range(1500, 2500);
 
     // All interval methods are available
     if (gdt::genomic_coordinate::overlaps(coord, other_coord)) {
@@ -206,6 +210,7 @@ int main() {
 **K-mer Characteristics:**
 
 - Encoding: 2-bit per nucleotide (A=00, C=01, G=10, T=11)
+- `BASE_MASK` — Named constant (`0x03`) for the 2-bit nucleotide mask used in `decode_base()`
 - Maximum length: 32 nucleotides (fits in 64-bit integer)
 - Comparison: Orders by k-value first, then encoding
 - Overlap: Exact sequence match required

--- a/source/guide/examples.md
+++ b/source/guide/examples.md
@@ -84,11 +84,11 @@ int main() {
             // Only process gene features
             if (entry.type != "gene") continue;
 
-            // Create genomic coordinate with strand (convert half-open to closed)
+            // Create genomic coordinate with strand (GFF is 1-based inclusive)
             gdt::genomic_coordinate coord{
                 entry.strand.value_or('.'),
                 entry.start,
-                entry.end - 1
+                entry.end
             };
 
             // Extract annotation info
@@ -160,10 +160,10 @@ int main() {
 
             auto transcript_id = entry.get_transcript_id().value_or("unknown");
 
-            // Insert exon (convert half-open to closed)
+            // Insert exon (GFF is 1-based inclusive)
             auto* exon_key = transcripts.insert_data(
                 entry.seqid,
-                gdt::interval(entry.start, entry.end - 1),
+                gdt::interval(entry.start, entry.end),
                 transcript_id,
                 gst::sorted
             );

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -138,6 +138,22 @@ groves.push_back(std::move(my_grove));
 
 Always pass groves by reference or move them explicitly with `std::move`.
 
+## Accessing Indices
+
+Use `get_root_nodes()` to access the grove's index map (chromosome → root node). It returns a
+**const reference** to the internal `std::unordered_map`, so use `.at()` or `.find()` for lookups
+(not `operator[]`, which requires a non-const map). The reference is valid only while the grove is
+alive and unmodified.
+
+```cpp
+const auto& roots = my_grove.get_root_nodes();
+if (auto it = roots.find("chr1"); it != roots.end()) {
+    // it->second is the root node for chr1
+}
+```
+
+`set_root_nodes()` is private — indices are created automatically on first insertion.
+
 ## Inserting Data
 
 The grove supports multiple insertion modes with multi-index organization:
@@ -307,7 +323,8 @@ The grove uses C++20 concepts to provide clear compile-time errors:
 
 - `link_if(keys, predicate)` requires `std::invocable<Predicate, key*, key*>`
 - `get_neighbors_if(source, predicate)` requires `std::predicate<Predicate, const edge_data_type&>`
-- Bulk insert `Container` parameters require `std::ranges::input_range<Container>`
+- `insert_data(index, data, sorted, bulk)` and `build_tree_bottom_up`: `Container` must satisfy `std::ranges::forward_range` and `std::ranges::sized_range`
+- `insert_data(index, data, bulk)`: `Container` must satisfy `std::ranges::random_access_range` and `std::ranges::sized_range`
 
 ```{toctree}
 :maxdepth: 1

--- a/source/guide/grove/loading_data.md
+++ b/source/guide/grove/loading_data.md
@@ -104,8 +104,9 @@ int main() {
     gio::gff_reader reader("annotations.gff.gz");
     try {
         for (const auto& entry : reader) {
+            // GFF coordinates are 1-based inclusive — use start and end directly
             my_grove.insert_data(entry.seqid,
-                                gdt::interval(entry.start, entry.end - 1),
+                                gdt::interval(entry.start, entry.end),
                                 entry.get_gene_id().value_or(entry.type),
                                 gst::sorted);
         }
@@ -156,7 +157,8 @@ int main() {
 
 ## Key Points
 
-- Readers produce 0-based half-open `[start, end)` coordinates; the grove uses closed `[start, end]` — subtract 1 from `end` when constructing `gdt::interval`
+- BED and BAM readers produce 0-based half-open `[start, end)` coordinates — subtract 1 from `end` when constructing `gdt::interval`
+- GFF/GTF readers produce 1-based inclusive `[start, end]` coordinates — use `start` and `end` directly with `gdt::interval`
 - File readers handle decompression automatically
 - For small files, use incremental insertion with `sorted` tag
 - For large files (>10K intervals), collect data and use bulk insertion with the `sorted` tag

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -101,8 +101,7 @@ gio::bed_reader reader("data.bed", gio::bed_reader_options{.skip_invalid_lines =
 // GFF: skip_invalid_lines
 // gio::gff_reader reader("data.gff", gio::gff_reader_options{.skip_invalid_lines = true});
 
-// BAM: skip_invalid_records
-// gio::bam_reader reader("data.bam", gio::bam_reader_options{.skip_invalid_records = true});
+// BAM: bam_reader throws only on I/O errors — no lenient mode option
 
 for (const auto& entry : reader) {
     // process entries — malformed lines are silently skipped
@@ -131,22 +130,28 @@ for (const auto& entry : reader) {
 
 ## Coordinate Semantics
 
-Readers and the grove use different coordinate conventions:
+Readers preserve format-native coordinate conventions. The grove uses **closed** `[start, end]` coordinates (both endpoints inclusive). When inserting reader entries, convert as needed:
 
-- **Readers** (`bed_reader`, `gff_reader`, `bam_reader`) produce **0-based half-open** `[start, end)` coordinates — matching their respective file format conventions.
-- **Grove** (`gdt::interval`) uses **closed** `[start, end]` coordinates — where `start` and `end` are both inclusive.
-
-When inserting reader entries into a grove, convert from half-open to closed:
+| Format    | Convention             | Conversion to grove interval                        |
+|-----------|------------------------|-----------------------------------------------------|
+| BED / BAM | 0-based half-open `[start, end)` | `gdt::interval(entry.start, entry.end - 1)` |
+| GFF / GTF | 1-based inclusive `[start, end]` | `gdt::interval(entry.start, entry.end)`      |
 
 ```cpp
-for (const auto& entry : reader) {
+// BED / BAM — subtract 1 from end
+for (const auto& entry : bed_reader) {
     grove.insert_data(entry.chrom,
                       gdt::interval(entry.start, entry.end - 1),
                       data);
 }
-```
 
-The `- 1` on `end` converts from half-open to closed. When outputting results, `entry.start` and `entry.end` retain the original format-native (half-open) values — no conversion needed for writing back to BED/GFF/BAM.
+// GFF / GTF — use start and end directly (both already inclusive)
+for (const auto& entry : gff_reader) {
+    grove.insert_data(entry.seqid,
+                      gdt::interval(entry.start, entry.end),
+                      data);
+}
+```
 
 ## BED Files
 
@@ -226,7 +231,7 @@ for (const auto& entry : reader) {
 
 GFF3 and GTF files contain gene annotations. The `gff_reader` auto-detects the format variant
 by inspecting the attribute column (GFF3 uses `key=value`, GTF uses `key "value"`).
-Coordinates are 1-based inclusive in the file and converted to 0-based half-open `[start, end)` values.
+Coordinates are stored in native GFF format: **1-based inclusive** `[start, end]`.
 
 ```cpp
 #include <genogrove/io/gff_reader.hpp>
@@ -269,8 +274,8 @@ int main() {
 - `seqid` (std::string): Chromosome/contig name
 - `source` (std::string): Source of the feature
 - `type` (std::string): Feature type (gene, exon, CDS, etc.)
-- `start` (size_t): Start position (0-based, half-open, converted from 1-based inclusive)
-- `end` (size_t): End position (0-based, half-open, converted from 1-based inclusive)
+- `start` (size_t): Start position (1-based inclusive, native GFF format)
+- `end` (size_t): End position (1-based inclusive, native GFF format)
 - `score` (std::optional\<double>): Score value (`std::nullopt` when `.` in file)
 - `strand` (std::optional\<char>): Strand (+, -, ., or ?)
 - `phase` (std::optional\<int>): Phase for CDS features (0, 1, or 2)
@@ -298,6 +303,12 @@ if (it != entry.attributes.end()) {
     std::cout << "ID: " << it->second << "\n";
 }
 ```
+
+### GTF Quoted Semicolons
+
+Semicolons inside double-quoted GTF attribute values (e.g., `gene_name "test;name"`) are correctly
+preserved. The parser recognizes that these are part of the value rather than field delimiters.
+GFF3 files are unaffected — GFF3 uses URL-encoding (`%3B`) for literal semicolons per spec.
 
 ### GTF Validation
 
@@ -394,7 +405,6 @@ gio::bam_reader reader5("reads.bam", opts);
 - `skip_qc_fail` (bool, default `false`): Skip QC-failed reads
 - `skip_duplicates` (bool, default `false`): Skip duplicate reads
 - `min_mapq` (uint8_t, default `0`): Minimum mapping quality
-- `skip_invalid_records` (bool, default `false`): Skip malformed records instead of throwing
 
 ### SAM Entry Fields
 

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -48,6 +48,7 @@ hex editors. Internally the data is written in a depth-first traversal:
 1. Tree order and number of indices (chromosomes)
 2. For each index: the index name followed by the full tree (nodes, keys, and associated data)
 3. External key storage
+4. Graph overlay edges
 
 All built-in key types (`interval`, `genomic_coordinate`, `numeric`, `kmer`) and common data types
 (`std::string`, trivially copyable types like `int`, `double`, `uint32_t`) are serialized automatically.
@@ -185,5 +186,6 @@ struct genogrove::data_type::serialization_traits<ThirdPartyType> {
 - All `deserialize` methods (`node::deserialize`, `grove::deserialize`, `registry::deserialize`, `serialization_traits<std::string>::deserialize`) throw `std::runtime_error` on corrupt or truncated streams
 - `node::deserialize` additionally validates B+ tree invariants (num_keys < order, num_children <= order)
 - The grove's `fill_factor` is included in the serialized format and restored on deserialize
-- Graph edges are **not** serialized — you must rebuild the graph overlay after deserialization
+- Graph edges added via `add_edge()` or `link_if()` are now persisted during serialization and restored on deserialize
+- **Breaking format change**: The serialized format now includes graph edges after external keys. Files serialized with older versions are incompatible and must be re-created.
 - All `deserialize` methods are marked `[[nodiscard]]` to prevent accidentally discarding the result


### PR DESCRIPTION
## Summary

Addresses all open documentation issues (except #15) in a single PR, since they are all non-conflicting doc updates for upstream API changes.

- **#85**: Document `get_root_nodes()` const-ref return semantics and note `set_root_nodes()` is private (also closes #72, #74)
- **#86**: Remove `skip_invalid_records` from `bam_reader_options` docs
- **#87**: Document `interval::INVALID_POSITION` and `kmer::BASE_MASK` named constants
- **#88**: Update GFF/GTF coordinate semantics — reader now stores native 1-based inclusive coordinates (no longer converts to 0-based half-open). Updated coordinate conversion table, examples in `io.md`, `loading_data.md`, and `examples.md`
- **#89**: Document GTF quoted semicolon handling
- **#90**: Replace `set_start()`/`set_end()` with `set_range()` in interval docs
- **#91**: Tighten bulk insert range concept docs (`forward_range`+`sized_range` / `random_access_range`+`sized_range`)
- **#92**: Document graph overlay edge serialization and breaking format change

Closes #85, closes #86, closes #87, closes #88, closes #89, closes #90, closes #91, closes #92

## Files changed

| File | Issues |
|------|--------|
| `source/guide/grove/grove.md` | #85, #91 |
| `source/guide/io.md` | #86, #88, #89 |
| `source/guide/data_types.md` | #87, #90 |
| `source/guide/serialization.md` | #92 |
| `source/guide/grove/loading_data.md` | #88 |
| `source/guide/examples.md` | #88 |

## Test plan

- [x] Run `make clean && make html` and verify no Sphinx build warnings
- [x] Review coordinate conversion table in io.md renders correctly
- [x] Verify cross-references between io.md, loading_data.md, and examples.md are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added documentation for accessing grove chromosome indices via `get_root_nodes()`.
  * Graph overlay edges now persisted in serialization.

* **Breaking Changes**
  * Removed BAM reader leniency option; malformed records now silently skipped.
  * Serialized groves with graph overlay edges incompatible with older formats; re-serialization required.
  * Interval API: replaced individual `set_start()`/`set_end()` with atomic `set_range()` method.

* **Documentation**
  * Clarified coordinate conventions: BED/BAM (0-based half-open) vs. GFF/GTF (1-based inclusive).
  * Updated GTF parsing behavior for semicolons in quoted attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->