### PR TITLE
Fix bulk insert API, wildcard strand, and version bump to 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Genogrove Documentation
 
 [![Read the Docs — Genogrove documentation](https://img.shields.io/readthedocs/genogrove)](https://genogrove.readthedocs.io/)
-[![Genogrove version](https://img.shields.io/badge/genogrove-v0.18.0-green.svg)](https://github.com/genogrove/genogrove)
+[![Genogrove version](https://img.shields.io/badge/genogrove-v0.19.0-green.svg)](https://github.com/genogrove/genogrove)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Sphinx](https://img.shields.io/badge/built%20with-Sphinx-blue.svg)](https://www.sphinx-doc.org/)
 [![MyST](https://img.shields.io/badge/markup-MyST%20Markdown-purple.svg)](https://myst-parser.readthedocs.io/)

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,7 +10,7 @@ import os
 project = "genogrove"
 copyright = "2026, Richard. A. Schaefer"
 author = "Richard. A. Schaefer"
-release = "0.18.0"
+release = "0.19.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/guide/data_types.md
+++ b/source/guide/data_types.md
@@ -83,7 +83,7 @@ int main() {
     size_t start = coord.get_start();
     size_t end = coord.get_end();
 
-    // Modify strand (validates: must be '+', '-', or '.')
+    // Modify strand (validates: must be '+', '-', '.', or '*')
     coord.set_strand('-');
 
     // Modify both positions atomically

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -236,14 +236,13 @@ namespace gst = genogrove::structure;
 int main() {
     gst::grove<gdt::interval, std::string> my_grove(100);
 
-    // Prepare sorted data
-    std::vector<gdt::interval> intervals = {
-        {100, 200}, {300, 400}, {500, 600}
+    // Prepare sorted data as a container of (key, data) pairs
+    std::vector<std::pair<gdt::interval, std::string>> data = {
+        {{100, 200}, "gene1"}, {{300, 400}, "gene2"}, {{500, 600}, "gene3"}
     };
-    std::vector<std::string> names = {"gene1", "gene2", "gene3"};
 
     // Bulk insert with sorted data (fastest method)
-    my_grove.insert_data("chr1", intervals, names, gst::sorted, gst::bulk);
+    my_grove.insert_data("chr1", data, gst::sorted, gst::bulk);
 
     return 0;
 }

--- a/source/guide/performance.md
+++ b/source/guide/performance.md
@@ -40,12 +40,11 @@ Sorted insertion provides O(1) amortized insertion time vs O(log n) for unsorted
 For loading large datasets (>10K intervals), bulk insertion provides dramatic performance improvements:
 
 ```cpp
-std::vector<gdt::interval> intervals = load_intervals();
-std::vector<std::string> data = load_data();
+std::vector<std::pair<gdt::interval, std::string>> data = load_data();
 
 // Bulk insertion - ~10-20x faster than incremental
 // Data must be sorted before calling this function
-grove.insert_data("chr1", intervals, data, gst::sorted, gst::bulk);
+grove.insert_data("chr1", data, gst::sorted, gst::bulk);
 ```
 
 **Runtime Characteristics:**


### PR DESCRIPTION
## Summary

- **#94**: Fix bulk insert examples in `grove.md` and `performance.md` — changed from non-existent separate-container API (`intervals, names`) to correct single container of pairs (`vector<pair<interval, string>>`)
- **#95**: Add `'*'` wildcard strand to `set_strand()` validation comment in `data_types.md`
- **#96**: Bump version from `0.18.0` to `0.19.0` in `conf.py` and README badge

Closes #94, closes #95, closes #96

## Test plan

- [x] Run `make clean && make html` and verify no Sphinx build warnings
- [x] Verify README badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version to v0.19.0 across documentation and badges.
  * Clarified strand validator now accepts `'+'`, `'-'`, `'.'`, or `'*'`.
  * Updated bulk insertion examples to reflect current API usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->