### PR TITLE
Document v0.20.x/v0.21.0 API changes (issues #98-#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Genogrove Documentation
 
 [![Read the Docs — Genogrove documentation](https://img.shields.io/readthedocs/genogrove)](https://genogrove.readthedocs.io/)
-[![Genogrove version](https://img.shields.io/badge/genogrove-v0.19.0-green.svg)](https://github.com/genogrove/genogrove)
+[![Genogrove version](https://img.shields.io/badge/genogrove-v0.21.0-green.svg)](https://github.com/genogrove/genogrove)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Sphinx](https://img.shields.io/badge/built%20with-Sphinx-blue.svg)](https://www.sphinx-doc.org/)
 [![MyST](https://img.shields.io/badge/markup-MyST%20Markdown-purple.svg)](https://myst-parser.readthedocs.io/)

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,7 +10,7 @@ import os
 project = "genogrove"
 copyright = "2026, Richard. A. Schaefer"
 author = "Richard. A. Schaefer"
-release = "0.19.0"
+release = "0.21.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/guide/grove/graph_manipulation.md
+++ b/source/guide/grove/graph_manipulation.md
@@ -369,6 +369,61 @@ grove.remove_edge(exon1, exon2);
 - Updating graph topology based on new evidence
 - Removing erroneous connections
 
+### Bulk edge removal
+
+For removing many edges at once, the grove provides bulk operations that forward to the underlying
+graph overlay. Each returns the number of edges removed.
+
+**Function Signatures:**
+
+```cpp
+size_t remove_edges_from(gdt::key<key_type, data_type>* source);
+size_t remove_edges_to(gdt::key<key_type, data_type>* target);
+size_t remove_all_edges(gdt::key<key_type, data_type>* key);
+
+template<typename Predicate>
+size_t remove_edges_if(Predicate predicate);
+```
+
+- **`remove_edges_from(source)`** — removes all outgoing edges from `source`. O(1) in the number of
+  sources (drops the adjacency entry).
+- **`remove_edges_to(target)`** — removes all incoming edges to `target`. O(E) — scans every
+  adjacency list in the graph.
+- **`remove_all_edges(key)`** — removes both incoming and outgoing edges for `key` (equivalent to
+  `remove_edges_from` + `remove_edges_to`).
+- **`remove_edges_if(predicate)`** — removes every edge for which `predicate(const edge&)` returns
+  `true`. Useful for threshold-based pruning on edge metadata. Requires
+  `std::predicate<Predicate, const edge&>`.
+
+**Example: clean up all edges for a retired key**
+
+```cpp
+gst::grove<gdt::interval, std::string, double> grove(100);
+
+auto* hub = grove.insert_data("chr1", gdt::interval{1000, 2000}, "hub");
+// ... add many edges pointing to and from hub ...
+
+size_t removed = grove.remove_all_edges(hub);
+std::cout << "Pruned " << removed << " edges\n";
+```
+
+**Example: drop low-confidence edges in a single pass**
+
+```cpp
+gst::grove<gdt::interval, std::string, double> grove(100);
+
+// ... build a graph where edge metadata is a confidence score ...
+
+auto dropped = grove.remove_edges_if(
+    [](const auto& e) { return e.metadata < 0.5; });
+std::cout << "Dropped " << dropped << " low-confidence edges\n";
+```
+
+```{note}
+`grove::remove_key(index, key)` already calls `remove_all_edges(key)` internally, so callers do
+not need to remove edges manually before removing a key from the tree.
+```
+
 ## Graph Statistics
 
 ### Counting outgoing edges (`out_degree`)

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -85,9 +85,9 @@ namespace gdt = genogrove::data_type;
 namespace gst = genogrove::structure;
 
 int main() {
-    // grove<key_type, data_type, edge_data_type>(order, fill_factor)
+    // grove<key_type, data_type, edge_data_type>(order)
     // Order determines max keys per node (higher = more cache-friendly)
-    // Order must be >= 2 (throws std::out_of_range otherwise)
+    // Order must be >= 3 (throws std::invalid_argument otherwise)
 
     // Using built-in interval type
     gst::grove<gdt::interval, std::string> grove1(100);
@@ -95,8 +95,8 @@ int main() {
     // Using genomic_coordinate (with strand)
     gst::grove<gdt::genomic_coordinate, std::string> grove2(100);
 
-    // With custom fill factor for sorted insertion splits (default: 1.0)
-    gst::grove<gdt::interval, std::string> grove3(100, 0.7f);
+    // Default-constructed grove uses order 3
+    gst::grove<gdt::interval, std::string> grove3;
 
     return 0;
 }
@@ -110,8 +110,10 @@ int main() {
 
 **Constructor Parameters:**
 
-- `order` (int): Maximum keys per node. Must be >= 2; throws `std::out_of_range` otherwise.
-- `fill_factor` (float, default `1.0f`): Controls how full the left node is after a sorted-path split. Must be in `[0.5, 1.0]`. At 1.0, leaves are packed fully (~100%). At 0.5, classic midpoint split. Use `get_fill_factor()` / `set_fill_factor()` to inspect or change after construction.
+- `order` (int): Maximum children per node (and `order - 1` keys). Must be `>= 3`; throws
+  `std::invalid_argument("grove order must be >= 3")` otherwise. Order 2 is degenerate — internal
+  splits with `order == 2` would produce a sibling with zero keys, which classical B+ trees forbid.
+  The default constructor (`grove()`) uses order 3.
 
 ## Ownership Semantics
 
@@ -269,6 +271,43 @@ For loading 1M intervals into an empty index:
 - Bulk insertion is most beneficial for datasets >10K intervals
 - When appending to existing data, ensure new keys are strictly greater than all existing keys in that index
 - Genomic files (BED, GFF, GTF) are typically pre-sorted by position
+
+## Removing Keys
+
+Use `remove_key()` to remove a previously-inserted key from the B+ tree. The method takes the
+index name (e.g., chromosome) and a pointer to the key — typically one that was returned from
+`insert_data()` or looked up via `intersect()`.
+
+```cpp
+gst::grove<gdt::interval, std::string> my_grove(100);
+
+auto* k = my_grove.insert_data("chr1", gdt::interval{100, 200}, "gene1", gst::sorted);
+
+// Remove the key. Returns true if found and removed, false otherwise.
+bool removed = my_grove.remove_key("chr1", k);
+```
+
+**Behaviour:**
+
+- Returns `true` if the key was found and removed, `false` otherwise (unknown index, null pointer,
+  or key not present in the index's tree).
+- Handles leaf underflow via borrow-from-sibling, merge, cascading rebalance, and root collapse —
+  the tree stays balanced automatically.
+- **Graph edges are cleaned up automatically**: all incoming and outgoing edges for the removed
+  key are dropped, so callers never need to call `remove_edge`/`remove_edges_from`/`remove_edges_to`
+  manually after `remove_key`.
+- The key object itself is *not* deallocated — it remains in the grove's internal deque so that
+  pointer stability is preserved. It is simply unlinked from the tree and graph.
+
+```cpp
+// Example: prune genes that fall below a coverage threshold
+auto results = my_grove.intersect(gdt::interval{0, 1000000}, "chr1");
+for (auto* key : results.get_keys()) {
+    if (coverage_of(key) < min_coverage) {
+        my_grove.remove_key("chr1", key);
+    }
+}
+```
 
 ## Querying Intervals
 

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -4,8 +4,9 @@ The `genogrove::io` namespace provides efficient readers for common genomic file
 
 ## Reader Ownership
 
-All file readers (`bed_reader`, `gff_reader`, `bam_reader`) own raw htslib resource pointers and are
-**non-copyable** but **movable**. Attempting to copy a reader will produce a compile error.
+All streaming file readers (`bed_reader`, `gff_reader`, `bam_reader`, `fasta_reader`) own raw
+htslib resource pointers and are **non-copyable** but **movable**. Attempting to copy a reader will
+produce a compile error. `fasta_index` (indexed random-access FASTA) follows the same rule.
 
 ```cpp
 namespace gio = genogrove::io;
@@ -53,6 +54,8 @@ int main() {
 - GFF (General Feature Format)
 - GTF (Gene Transfer Format)
 - BAM/SAM/CRAM (Sequence Alignments)
+- FASTA (`.fa`, `.fasta`, `.fna`)
+- FASTQ (`.fq`, `.fastq`, `.fnq`)
 - VCF (Variant Call Format)
 - GG (Genogrove native format)
 
@@ -476,4 +479,106 @@ std::cout << "Header:\n" << header << "\n";
 - `is_primary()` — not secondary and not supplementary
 - `is_mapped()` — not unmapped
 - `cigar_string_repr()` — CIGAR as a human-readable string (e.g. `"50M2I30M"`)
+
+## FASTA / FASTQ Files
+
+Genogrove provides two complementary APIs for FASTA/FASTQ data:
+
+- **`fasta_reader`** — streaming iteration over every record in a FASTA or FASTQ file
+  (including gzip-compressed variants). Follows the same `file_reader<EntryType>` iterator pattern
+  as the other readers. Backed by htslib's `kseq` parser.
+- **`fasta_index`** — indexed random-access reader for `.fa` / `.fasta` / `.fna` files. Fetches
+  regions or whole sequences in O(1) using a `.fai` index (auto-created on first use). Backed by
+  htslib's `faidx` API.
+
+### Streaming: `fasta_reader`
+
+```cpp
+#include <genogrove/io/fasta_reader.hpp>
+#include <iostream>
+
+namespace gio = genogrove::io;
+
+int main() {
+    gio::fasta_reader reader("reads.fq.gz");
+
+    for (const auto& entry : reader) {
+        std::cout << entry.name << " (" << entry.sequence.size() << " bp)\n";
+        if (entry.quality) {
+            std::cout << "  quality: " << *entry.quality << "\n";
+        }
+    }
+
+    if (!reader.get_error_message().empty()) {
+        std::cerr << reader.get_error_message() << "\n";
+    }
+    return 0;
+}
+```
+
+- Format (FASTA vs. FASTQ) is auto-detected per record by `kseq` — mixed `>` and `@` headers are
+  handled transparently.
+- `entry.quality` is `std::optional<std::string>` — populated for FASTQ records, `std::nullopt`
+  for FASTA records.
+- `fasta_reader_options{.skip_empty_sequences = true}` skips records whose sequence is empty.
+
+### FASTA Entry Fields
+
+- `name` (std::string): Sequence name (text after `>` or `@`, up to the first whitespace)
+- `comment` (std::string): Rest of the header line after the name (empty if none)
+- `sequence` (std::string): Nucleotide sequence
+- `quality` (std::optional\<std::string>): Per-base quality string (FASTQ only, `std::nullopt` for FASTA)
+
+### Indexed Access: `fasta_index`
+
+`fasta_index` is useful when you already have genomic coordinates (e.g., from a BED or GFF file)
+and want to pull out the underlying sequence without scanning the entire FASTA.
+
+```cpp
+#include <genogrove/io/fasta_index.hpp>
+#include <iostream>
+
+namespace gio = genogrove::io;
+
+int main() {
+    // Opens the FASTA and loads (or creates) its .fai index.
+    gio::fasta_index fasta("genome.fa");
+
+    // Fetch a region — coordinates are 0-based half-open [start, end),
+    // matching BED / BAM conventions.
+    std::string promoter = fasta.fetch("chr1", 1000, 2000);
+
+    // Fetch an entire sequence by name.
+    std::string chrM = fasta.fetch("chrM");
+
+    // Enumerate sequences in the index.
+    for (size_t i = 0; i < fasta.sequence_count(); ++i) {
+        auto name = fasta.sequence_name(i);
+        std::cout << name << ": " << fasta.sequence_length(name) << " bp\n";
+    }
+
+    if (fasta.has_sequence("chrUn")) {
+        // ...
+    }
+}
+```
+
+**Coordinate reminder**: `fetch(name, start, end)` follows BED/BAM's 0-based half-open convention.
+When pairing with a GFF/GTF record (which is 1-based inclusive), shift the start by one:
+
+```cpp
+// GFF: 1-based inclusive [start, end] → FASTA: 0-based half-open [start-1, end)
+for (const auto& entry : gff_reader) {
+    std::string seq = fasta.fetch(entry.seqid, entry.start - 1, entry.end);
+    // ...
+}
+```
+
+**Notes:**
+
+- `fasta_index` throws `std::out_of_range` on unknown sequence names and `std::runtime_error` on
+  I/O or fetch failures.
+- The `.fai` file is created on first use if missing (requires write permission to the FASTA
+  directory).
+- `fasta_index` is non-copyable and movable.
 

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -502,15 +502,15 @@ namespace gio = genogrove::io;
 int main() {
     gio::fasta_reader reader("reads.fq.gz");
 
-    for (const auto& entry : reader) {
-        std::cout << entry.name << " (" << entry.sequence.size() << " bp)\n";
-        if (entry.quality) {
-            std::cout << "  quality: " << *entry.quality << "\n";
+    try {
+        for (const auto& entry : reader) {
+            std::cout << entry.name << " (" << entry.sequence.size() << " bp)\n";
+            if (entry.quality) {
+                std::cout << "  quality: " << *entry.quality << "\n";
+            }
         }
-    }
-
-    if (!reader.get_error_message().empty()) {
-        std::cerr << reader.get_error_message() << "\n";
+    } catch (const std::runtime_error& e) {
+        std::cerr << "Parse error: " << e.what() << "\n";
     }
     return 0;
 }
@@ -521,6 +521,8 @@ int main() {
 - `entry.quality` is `std::optional<std::string>` — populated for FASTQ records, `std::nullopt`
   for FASTA records.
 - `fasta_reader_options{.skip_empty_sequences = true}` skips records whose sequence is empty.
+- `fasta_reader` has no lenient mode: `read_next()` throws `std::runtime_error` on truncated
+  quality strings or I/O errors, so use the same try/catch pattern shown for `bam_reader` above.
 
 ### FASTA Entry Fields
 

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -185,7 +185,6 @@ struct genogrove::data_type::serialization_traits<ThirdPartyType> {
 - `grove::deserialize()` returns a grove **by value**. Because `grove` is a move-only type (copy is deleted), the return relies on Named Return Value Optimization (NRVO) or implicit move. No special handling is needed—just assign the result to a local variable as shown in the examples above.
 - All `deserialize` methods (`node::deserialize`, `grove::deserialize`, `registry::deserialize`, `serialization_traits<std::string>::deserialize`) throw `std::runtime_error` on corrupt or truncated streams
 - `node::deserialize` additionally validates B+ tree invariants (num_keys < order, num_children <= order)
-- The grove's `fill_factor` is included in the serialized format and restored on deserialize
 - Graph edges added via `add_edge()` or `link_if()` are now persisted during serialization and restored on deserialize
 - **Breaking format change**: The serialized format now includes graph edges after external keys. Files serialized with older versions are incompatible and must be re-created.
 - All `deserialize` methods are marked `[[nodiscard]]` to prevent accidentally discarding the result

--- a/source/index.md
+++ b/source/index.md
@@ -12,7 +12,7 @@ Genogrove provides a specialized B+ tree data structure (the **grove**) optimize
 - **Multi-Index Organization**: Separate trees per chromosome for efficient queries
 - **Sorted Insertion**: O(1) amortized insertion for pre-sorted genomic data
 - **Graph Overlay**: Link keys within the grove to represent feature relationships
-- **File I/O**: Automatic format detection and compression support (BED, GFF/GTF, VCF)
+- **File I/O**: Automatic format detection and compression support (BED, GFF/GTF, BAM/SAM, FASTA/FASTQ)
 - **Modern C++20**: Type-safe, concept-based design
 
 ## Quick Example

--- a/source/reference/cpp/io.md
+++ b/source/reference/cpp/io.md
@@ -36,6 +36,22 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
+### fasta_reader
+
+```{eval-rst}
+.. doxygenclass:: genogrove::io::fasta_reader
+   :members:
+   :undoc-members:
+```
+
+### fasta_index
+
+```{eval-rst}
+.. doxygenclass:: genogrove::io::fasta_index
+   :members:
+   :undoc-members:
+```
+
 
 ## Entry Types
 
@@ -63,6 +79,14 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
+### fasta_entry
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::fasta_entry
+   :members:
+   :undoc-members:
+```
+
 ## Reader Options
 
 ### bed_reader_options
@@ -85,6 +109,14 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
 
 ```{eval-rst}
 .. doxygenstruct:: genogrove::io::bam_reader_options
+   :members:
+   :undoc-members:
+```
+
+### fasta_reader_options
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::fasta_reader_options
    :members:
    :undoc-members:
 ```


### PR DESCRIPTION
## Summary

Batched documentation update for the API changes in genogrove v0.20.x / v0.21.0.

Closes #98, #99, #100, #101.

### #101 — grove minimum order
- `grove.md`: constructor now documented as `order >= 3` throwing `std::invalid_argument("grove order must be >= 3")`. Dropped stale `fill_factor` parameter and the `grove(100, 0.7f)` example.

### #100 — B+ tree key removal and API cleanup
- `grove.md`: new **Removing Keys** section covering `remove_key(index, key)` — return semantics, leaf-underflow/rebalance/root-collapse behaviour, auto-cleanup of incoming/outgoing graph edges, and pointer-stability guarantees.
- `graph_manipulation.md`: new **Bulk edge removal** subsection documenting `remove_edges_from`, `remove_edges_to`, `remove_all_edges`, and `remove_edges_if` (with examples for single-key cleanup and threshold-based pruning).
- `serialization.md`: removed the stale bullet claiming `fill_factor` is part of the serialized format.

### #99 + #98 — FASTA/FASTQ readers and indexed FASTA
- `io.md` guide: new **FASTA / FASTQ Files** section covering streaming (`fasta_reader`, `fasta_entry`, `fasta_reader_options`) and indexed random access (`fasta_index`), including the GFF→FASTA coordinate example (`fasta.fetch(entry.seqid, entry.start - 1, entry.end)`). Supported file types list and reader ownership note updated.
- `reference/cpp/io.md`: added doxygen directives for `fasta_reader`, `fasta_index`, `fasta_entry`, `fasta_reader_options`.
- Issue #98 was filed against the original `sequence_reader`/`sequence_entry` names; the new docs use the final `fasta_*` names from PR genogrove#298, so both issues are resolved in one pass.

### Docs-sync follow-through (v0.19.0 → v0.21.0)
- `index.md`: replaced the outdated "BED, GFF/GTF, VCF" feature bullet with "BED, GFF/GTF, BAM/SAM, FASTA/FASTQ".
- Version bump `0.19.0` → `0.21.0` in `source/conf.py` and the `README.md` badge.

## Test plan

- [ ] `make clean && make html` — verify no new Sphinx warnings
- [ ] Visually check the new **Removing Keys**, **Bulk edge removal**, and **FASTA / FASTQ Files** sections render correctly
- [ ] Confirm Breathe picks up the new `fasta_reader` / `fasta_index` / `fasta_entry` / `fasta_reader_options` doxygen directives (Doxygen XML must be up to date for the v0.21.0 submodule state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FASTA/FASTQ file I/O support with streaming and indexed random access capabilities.
  * Bulk edge removal operations for efficient graph manipulation.
  * Key removal functionality with automatic rebalancing for grove structures.

* **Documentation**
  * Updated grove construction semantics and constraints documentation.

* **Chores**
  * Version bumped to v0.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->