### PR TITLE
Document v0.22.0 API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Genogrove Documentation
 
 [![Read the Docs — Genogrove documentation](https://img.shields.io/readthedocs/genogrove)](https://genogrove.readthedocs.io/)
-[![Genogrove version](https://img.shields.io/badge/genogrove-v0.21.0-green.svg)](https://github.com/genogrove/genogrove)
+[![Genogrove version](https://img.shields.io/badge/genogrove-v0.22.0-green.svg)](https://github.com/genogrove/genogrove)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Sphinx](https://img.shields.io/badge/built%20with-Sphinx-blue.svg)](https://www.sphinx-doc.org/)
 [![MyST](https://img.shields.io/badge/markup-MyST%20Markdown-purple.svg)](https://myst-parser.readthedocs.io/)

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,7 +10,7 @@ import os
 project = "genogrove"
 copyright = "2026, Richard. A. Schaefer"
 author = "Richard. A. Schaefer"
-release = "0.21.0"
+release = "0.22.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -364,6 +364,82 @@ The grove uses C++20 concepts to provide clear compile-time errors:
 - `insert_data(index, data, sorted, bulk)` and `build_tree_bottom_up`: `Container` must satisfy `std::ranges::forward_range` and `std::ranges::sized_range`
 - `insert_data(index, data, bulk)`: `Container` must satisfy `std::ranges::random_access_range` and `std::ranges::sized_range`
 
+## Flanking-Key Queries
+
+In addition to `intersect()`, which finds keys that overlap a query, the grove supports a
+`flanking()` query that returns the **predecessor** and **successor** of a query — the
+two nearest non-overlapping keys that bracket it in sort order. This is useful when the
+caller needs the closest features on each side of a position rather than the features
+covering it (for example, the upstream and downstream genes of an enhancer).
+
+```cpp
+#include <genogrove/structure/grove/grove.hpp>
+#include <genogrove/data_type/interval.hpp>
+
+namespace gdt = genogrove::data_type;
+namespace gst = genogrove::structure;
+
+gst::grove<gdt::interval, std::string> g(100);
+g.insert_data("chr1", gdt::interval{100, 200}, "A", gst::sorted);
+g.insert_data("chr1", gdt::interval{500, 600}, "B", gst::sorted);
+g.insert_data("chr1", gdt::interval{900, 1000}, "C", gst::sorted);
+
+auto r = g.flanking(gdt::interval{650, 700}, "chr1");
+
+if (auto* pred = r.get_predecessor()) {
+    // "B" — largest non-overlapping key < query
+}
+if (auto* succ = r.get_successor()) {
+    // "C" — smallest non-overlapping key > query
+}
+```
+
+Each field of the returned `flanking_query_result` may be `nullptr` if no such
+key exists (for example, the query is past the rightmost key, or the index does
+not exist). Returned pointers reference keys owned by the grove and remain valid
+as long as the referenced key is not removed.
+
+**Selection rule.** Keys that satisfy `key_type::overlaps(K, query)` are
+excluded by definition. Among the remaining candidates:
+
+- For interval-like keys (`interval`, `genomic_coordinate`), the predecessor is the key
+  with the largest `end` below `query.start` (smallest left-side gap), and the successor
+  is the key with the smallest `start` above `query.end` (smallest right-side gap). For
+  nested intervals these can differ from the sort-order extremum — e.g., between `[50, 100]`
+  and `[80, 90]`, sort picks `[80, 90]` but `[50, 100]` is closer to a query at `[150, …]`.
+- For scalar keys (`numeric`, `kmer`), nearest-by-value coincides with the sort-order
+  extremum, so the predecessor/successor are simply the closest values on each side.
+
+**Distance is computed by the caller** because it is type-specific. For closed-coord
+intervals: `query.start - predecessor->get_value().get_end() - 1`; for numeric scalars:
+`query.value - predecessor->get_value()`.
+
+### Filtering by a Predicate
+
+A second overload accepts a binary predicate `is_compatible(candidate, query)` that
+filters candidates before the overlap and ordering checks. Use this to express
+domain-specific constraints that are not encoded in `key_type::overlaps()` — for
+example, restricting the search to same-strand neighbors:
+
+```cpp
+auto r = grove.flanking(q, "chr1",
+    [](const auto& candidate, const auto& q) {
+        return q.get_strand() == '*' || candidate.get_strand() == '*'
+            || candidate.get_strand() == q.get_strand();
+    });
+```
+
+The predicate is invoked at leaf level only. Internal-node pruning is purely
+structural (based on aggregate ranges) and never consults the predicate, so
+subtrees that contain only incompatible keys are still visited but filtered
+out at the leaves.
+
+```{note}
+`flanking()` is named to avoid collision with the graph-overlay `get_neighbors()`,
+which returns graph-edge-connected keys — a distinct concept from spatial nearest
+neighbors.
+```
+
 ```{toctree}
 :maxdepth: 1
 

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -355,6 +355,9 @@ int main() {
 - Accepts temporaries and named variables (const reference parameter)
 - Returns `query_result` containing matching keys
 
+For the closest features on each side of a query (rather than features overlapping
+it), see [Flanking-Key Queries](#flanking-key-queries) below.
+
 **Concept Constraints:**
 
 The grove uses C++20 concepts to provide clear compile-time errors:
@@ -379,6 +382,8 @@ covering it (for example, the upstream and downstream genes of an enhancer).
 namespace gdt = genogrove::data_type;
 namespace gst = genogrove::structure;
 
+// flanking() works on any populated grove regardless of how it was built —
+// `gst::sorted` here is just for parity with surrounding examples.
 gst::grove<gdt::interval, std::string> g(100);
 g.insert_data("chr1", gdt::interval{100, 200}, "A", gst::sorted);
 g.insert_data("chr1", gdt::interval{500, 600}, "B", gst::sorted);
@@ -419,15 +424,23 @@ intervals: `query.start - predecessor->get_value().get_end() - 1`; for numeric s
 A second overload accepts a binary predicate `is_compatible(candidate, query)` that
 filters candidates before the overlap and ordering checks. Use this to express
 domain-specific constraints that are not encoded in `key_type::overlaps()` — for
-example, restricting the search to same-strand neighbors:
+example, restricting the search to same-strand neighbors when keys carry strand
+information:
 
 ```cpp
+// Assumes a grove parameterised with genomic_coordinate (which carries strand);
+//   gst::grove<gdt::genomic_coordinate, /* data */> grove(...);
+//   gdt::genomic_coordinate q{...};
 auto r = grove.flanking(q, "chr1",
     [](const auto& candidate, const auto& q) {
         return q.get_strand() == '*' || candidate.get_strand() == '*'
             || candidate.get_strand() == q.get_strand();
     });
 ```
+
+The `get_strand()` calls assume `genomic_coordinate` keys; for plain `interval`
+keys (no strand), use a predicate that inspects whatever metadata your key
+type exposes.
 
 The predicate is invoked at leaf level only. Internal-node pruning is purely
 structural (based on aggregate ranges) and never consults the predicate, so

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -67,6 +67,13 @@ int main() {
 - ZSTD (.zst)
 - LZ4 (.lz4)
 
+For `bed_reader` and `gff_reader`, both BGZF (block-gzip, `bgzip`) and plain gzip
+(`gzip`) compressed inputs are accepted with the `.gz` extension — internally they
+share htslib's `bgzf_open()`, which reads both formats transparently. BGZF files
+support random-access seeks; plain gzip files are read sequentially. This is useful
+when consuming files from sources that distribute plain-gzip compression (e.g.,
+ENCODE GTFs, GENCODE annotations) — there is no need to re-compress with `bgzip`.
+
 ## Error Handling
 
 All file readers throw `std::runtime_error` on parse and I/O errors by default. The `read_next()`
@@ -130,6 +137,49 @@ for (const auto& entry : reader) {
     // process valid entry...
 }
 ```
+
+### Zero-Record Inputs
+
+For `bed_reader` and `gff_reader`, structurally valid inputs that contain no records — empty files,
+files where every line is blank, and files that contain only `#`-prefixed comments or header lines —
+are **not** an error. The constructor returns successfully and the iterator immediately compares
+equal to `end()`, so the body of a `for (...)` loop simply runs zero times.
+
+This means callers decide the policy for "no data" rather than the reader. Detect zero records
+either by checking inside the loop or by comparing iterators directly:
+
+```cpp
+gio::gff_reader reader(path);
+
+bool any = false;
+for (const auto& entry : reader) {
+    any = true;
+    // process entry...
+}
+if (!any) {
+    // no records — consumer-defined policy: warn, skip, or fail
+}
+```
+
+The single-pass iterator returned by `begin()` is consumed as it is advanced, so when checking
+without iterating, call `begin()` exactly once:
+
+```cpp
+gio::gff_reader reader(path);
+if (reader.begin() == reader.end()) {
+    // no records
+}
+// do not iterate again — begin() already consumed the (non-existent) first record
+```
+
+The following error conditions still throw `std::runtime_error` (or skip the line, in lenient mode):
+
+- File-open failures (missing file, permission denied, unreadable BGZF header)
+- Malformed first record that fails to parse
+- Per-line parse errors discovered mid-iteration
+
+In other words, "valid file with zero records" is now a quiet success; only structurally broken
+inputs raise.
 
 ## Coordinate Semantics
 

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -161,15 +161,18 @@ if (!any) {
 }
 ```
 
-The single-pass iterator returned by `begin()` is consumed as it is advanced, so when checking
-without iterating, call `begin()` exactly once:
+The iterator is single-pass: each call to `begin()` on a reader that still has data
+consumes the next record from the underlying stream (the iterator's constructor calls
+`read_next()` eagerly so that `*it` is immediately valid). Call `begin()` at most once
+per reader. When detecting empty inputs without iterating, do the comparison and stop:
 
 ```cpp
 gio::gff_reader reader(path);
 if (reader.begin() == reader.end()) {
-    // no records
+    // no records — safe: begin() consumed nothing because the file was empty
 }
-// do not iterate again — begin() already consumed the (non-existent) first record
+// do not call begin() again on the same reader if you already called it above —
+// for a non-empty file, that second call would skip the first record
 ```
 
 The following error conditions still throw `std::runtime_error` (or skip the line, in lenient mode):
@@ -179,7 +182,7 @@ The following error conditions still throw `std::runtime_error` (or skip the lin
 - Per-line parse errors discovered mid-iteration
 
 In other words, "valid file with zero records" is now a quiet success; only structurally broken
-inputs raise.
+inputs raise errors.
 
 ## Coordinate Semantics
 

--- a/source/reference/cpp/data_type.md
+++ b/source/reference/cpp/data_type.md
@@ -45,6 +45,14 @@ All built-in key types (`interval`, `genomic_coordinate`, `numeric`, `kmer`) sat
    :undoc-members:
 ```
 
+## flanking_query_result
+
+```{eval-rst}
+.. doxygenclass:: genogrove::data_type::flanking_query_result
+   :members:
+   :undoc-members:
+```
+
 ## numeric
 
 ```{eval-rst}


### PR DESCRIPTION
## Summary

- Document `grove::flanking()` — predecessor/successor query API and `flanking_query_result` (#103)
- Note that `gff_reader`/`bed_reader` accept both BGZF and plain gzip (#104)
- Document new zero-record behavior for `gff_reader`/`bed_reader` (#105)
- Bump docs version to v0.22.0 in `source/conf.py` and the README badge (#106)

Closes #103, #104, #105, #106.

## Changes

- `source/guide/grove/grove.md` — new "Flanking-Key Queries" section covering both overloads, the selection rule for interval vs. scalar keys, and the predicate-filter use case
- `source/reference/cpp/data_type.md` — Doxygen stub for `flanking_query_result`
- `source/guide/io.md` — BGZF / plain gzip note in the compression list, plus a new "Zero-Record Inputs" subsection in Error Handling that documents the empty-iterator pattern and the failure modes that still throw
- `source/conf.py`, `README.md` — version 0.21.0 → 0.22.0

## Test plan

- [x] `make clean && make html` builds without Sphinx warnings
- [x] Reviewer spot-checks the new flanking section against `grove::flanking()` semantics
- [x] Reviewer confirms the zero-record copy matches the actual reader behavior on empty / comments-only files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.22.0

* **New Features**
  * Added flanking-key queries for grove data structures to retrieve bracketing predecessor and successor keys.

* **Documentation**
  * Clarified BGZF and plain gzip compatibility for file readers.
  * Documented zero-record input handling and error conditions.
  * Added API reference for flanking query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->