### PR TITLE
Fix critical doc issues: license, registry API, performance.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Read the Docs — Genogrove documentation](https://img.shields.io/readthedocs/genogrove)](https://genogrove.readthedocs.io/)
 [![Genogrove version](https://img.shields.io/badge/genogrove-v0.22.0-green.svg)](https://github.com/genogrove/genogrove)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Sphinx](https://img.shields.io/badge/built%20with-Sphinx-blue.svg)](https://www.sphinx-doc.org/)
 [![MyST](https://img.shields.io/badge/markup-MyST%20Markdown-purple.svg)](https://myst-parser.readthedocs.io/)
 

--- a/source/guide/data_types/registry.md
+++ b/source/guide/data_types/registry.md
@@ -1,6 +1,6 @@
 # Registry
 
-The `registry` is a singleton registry for storing shared metadata by ID, reducing memory usage when many grove entries share the same metadata (e.g., sample information, experiment details):
+The `registry<T>` is a per-type singleton that **interns** values: every distinct value gets one stable 4-byte ID, and asking to intern the same value again returns the existing ID. This is useful for collapsing many references to the same value (chromosome names, transcript/gene IDs, sample identifiers seen thousands of times across grove entries) down to a single ID that can be stored alongside grove keys.
 
 ```cpp
 #include <genogrove/data_type/registry.hpp>
@@ -10,64 +10,124 @@ The `registry` is a singleton registry for storing shared metadata by ID, reduci
 
 namespace gdt = genogrove::data_type;
 
-struct SampleInfo {
-    std::string name;
-    std::string tissue;
-    int replicate;
-};
-
 int main() {
-    // 1. Get the singleton registry for SampleInfo
-    auto& registry = gdt::registry<SampleInfo>::instance();
+    // 1. Get the singleton registry for std::string
+    auto& reg = gdt::registry<std::string>::instance();
 
-    // 2. Register data and get an ID
-    uint32_t id1 = registry.register_data(SampleInfo{"sample1", "liver", 1});
-    uint32_t id2 = registry.register_data(SampleInfo{"sample2", "kidney", 1});
+    // 2. Intern values — dedup-on-insert
+    auto id1 = reg.intern("chr1");   // 0 (new)
+    auto id2 = reg.intern("chr1");   // 0 (existing — same ID as id1)
+    auto id3 = reg.intern("chr2");   // 1 (new)
 
-    // 3. Check registry state
-    size_t count = registry.size();          // 2
-    bool is_empty = registry.empty();        // false
-    bool has_id1 = registry.contains(id1);   // true
-    bool has_999 = registry.contains(999);   // false
+    // 3. Probe without inserting
+    if (auto maybe = reg.find("chr3"); !maybe) {
+        std::cout << "chr3 has not been interned\n";
+    }
+    auto found = reg.find("chr1");   // std::optional<id_type>{0}
 
-    // 4. Retrieve data by ID (returns reference, throws std::out_of_range if invalid)
-    const SampleInfo& info = registry.get(id1);
-    std::cout << info.name << "\n";  // "sample1"
+    // 4. Resolve an ID back to its value (const access only)
+    const std::string& chrom = reg.get(id1);  // "chr1"
 
-    // 5. Mutable access
-    SampleInfo& mutable_info = registry.get(id2);
-    mutable_info.replicate = 2;  // modify in place
+    // 5. Registry state
+    size_t count = reg.size();          // 2
+    bool is_empty = reg.empty();        // false
+    bool has_id1 = reg.contains(id1);   // true
+    bool has_999 = reg.contains(999);   // false
 
-    // 6. Use with grove - store lightweight ID instead of full struct
+    // 6. Use with grove — store 4-byte IDs instead of full strings
     // grove<interval, uint32_t> g;
     // g.insert_data("chr1", interval{100, 200}, id1);
 
     // 7. Serialization
     std::ostringstream oss(std::ios::binary);
-    registry.serialize(oss);
+    reg.serialize(oss);
 
-    // 8. Deserialization (clears and repopulates the singleton)
+    // 8. Deserialization (clears the singleton and repopulates it)
     std::istringstream iss(oss.str(), std::ios::binary);
-    auto& restored = gdt::registry<SampleInfo>::deserialize(iss);
+    auto& restored = gdt::registry<std::string>::deserialize(iss);
 
-    // 9. Clear registry (invalidates all IDs - use with caution)
-    registry.clear();
+    // 9. Clear the registry (invalidates all IDs — use with caution)
+    reg.clear();
     // Or via static method:
-    gdt::registry<SampleInfo>::reset();
+    gdt::registry<std::string>::reset();
 
     return 0;
 }
 ```
 
-**Registry Features:**
+## The `registry_value` Concept
+
+`registry<T>` constrains `T` with the `registry_value` concept, which requires `T` to be:
+
+- **Equality-comparable** (`std::equality_comparable`) — used to detect existing entries.
+- **Hashable** via `std::hash<T>` — used by the internal value→ID lookup.
+
+Built-in types like `std::string`, `int`, and trivial wrappers satisfy this out of the box. Custom types need both `operator==` and a `std::hash` specialization:
+
+```cpp
+struct SampleInfo {
+    std::string name;
+    std::string tissue;
+    int replicate;
+
+    bool operator==(const SampleInfo& other) const {
+        return name == other.name
+            && tissue == other.tissue
+            && replicate == other.replicate;
+    }
+};
+
+template <>
+struct std::hash<SampleInfo> {
+    size_t operator()(const SampleInfo& s) const noexcept {
+        size_t h1 = std::hash<std::string>{}(s.name);
+        size_t h2 = std::hash<std::string>{}(s.tissue);
+        size_t h3 = std::hash<int>{}(s.replicate);
+        return h1 ^ (h2 << 1) ^ (h3 << 2);
+    }
+};
+
+auto& reg = gdt::registry<SampleInfo>::instance();
+auto id = reg.intern(SampleInfo{"sample1", "liver", 1});
+```
+
+Without these, the registry will fail to compile with a clear `registry_value` constraint error.
+
+## Thread Safety
+
+`registry<T>` is safe to use concurrently:
+
+- **Lock-protected:** `intern()`, `find()`, `clear()`, `serialize()`, `deserialize()` acquire an internal `std::mutex`.
+- **Unlocked fast paths:** `get(id)`, `contains(id)`, `size()`, `empty()`.
+
+`get(id)` is safe to call concurrently with `intern()` as long as `id` was obtained from an `intern()` call that **happens-before** the `get()` (the natural pattern: one thread interns and publishes the returned ID via a queue, atomic, or thread join, and another thread then reads it). `size()`, `empty()`, and `contains()` return best-effort snapshots under concurrent writes.
+
+## Why Dedup-on-Insert?
+
+Calling `intern(x)` is idempotent: `intern(x) == intern(x)` for all `x`. This means callers don't have to maintain their own value→ID map — the registry collapses N references to the same value down to a single ID slot:
+
+```cpp
+auto& reg = gdt::registry<std::string>::instance();
+
+// 10,000 BED entries on chr1 → only one registry slot
+for (const auto& entry : reader) {
+    auto chrom_id = reg.intern(entry.chrom);
+    grove.insert_data(entry.chrom, interval{...}, chrom_id);
+}
+
+// reg.size() is the number of distinct chromosomes, not the number of entries.
+```
+
+## Registry Features
 
 - `instance()`: Get the singleton registry for a given type
-- `register_data(data)`: Store data and return its ID (no deduplication)
-- `get(id)`: Retrieve data by ID (returns reference, throws `std::out_of_range` if invalid)
+- `intern(value)`: Intern a value and return its stable ID; returns the existing ID if already interned (dedup-on-insert, `[[nodiscard]]`)
+- `find(value)`: Look up a value without inserting; returns `std::optional<id_type>`
+- `get(id)`: Retrieve a value by ID (returns `const T&`, throws `std::out_of_range` on invalid ID)
 - `contains(id)`: Check if an ID is valid
 - `size()`, `empty()`: Query registry state
 - `clear()`, `reset()`: Clear all data (invalidates all IDs)
 - `serialize(os)`, `deserialize(is)`: Persist and restore registry data
 - `null_id`: Sentinel value representing an invalid/unset ID
 
-Each type `T` gets its own independent singleton registry.
+Each type `T` gets its own independent singleton registry with its own ID space.

--- a/source/guide/performance.md
+++ b/source/guide/performance.md
@@ -29,8 +29,8 @@ When data is already sorted (common for BED/GFF files), use sorted insertion:
 // For sorted data (e.g., BED files)
 grove.insert_data(index, interval, data, gst::sorted);  // Much faster!
 
-// For unsorted data
-grove.insert_data(index, interval, data, gst::unsorted);  // Default
+// For unsorted data — no tag, full tree traversal (O(log n))
+grove.insert_data(index, interval, data);
 ```
 
 Sorted insertion provides O(1) amortized insertion time vs O(log n) for unsorted.
@@ -185,10 +185,11 @@ Save and load grove structures for faster startup:
 - Tree structure
 - All keys and data
 - Order parameter
+- External (graph-only) keys
+- Graph overlay edges (with metadata when `edge_data_type` is non-void)
 
 **Not saved:**
 
-- Graph edges (must be rebuilt)
 - Rightmost node cache (recalculated on load)
 
 ## Query Optimization

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -69,9 +69,9 @@ int main() {
     auto& reg = gdt::registry<std::string>::instance();
     gst::grove<gdt::interval, uint32_t> my_grove(100);
 
-    // Register shared metadata, store IDs in the grove
-    auto id1 = reg.register_data("SampleA_liver");
-    auto id2 = reg.register_data("SampleB_brain");
+    // Intern shared metadata, store IDs in the grove
+    auto id1 = reg.intern("SampleA_liver");
+    auto id2 = reg.intern("SampleB_brain");
     my_grove.insert_data("chr1", gdt::interval{100, 200}, id1);
     my_grove.insert_data("chr1", gdt::interval{150, 250}, id2);
 

--- a/source/index.md
+++ b/source/index.md
@@ -116,7 +116,7 @@ GitHub Repository
 
 ## License
 
-Genogrove is distributed under the [MIT License](https://opensource.org/licenses/MIT).
+genogrove is distributed under the [GNU General Public License v3.0 or later](https://www.gnu.org/licenses/gpl-3.0.html).
 
 ```{toctree}
 :caption: Documentation


### PR DESCRIPTION
## Summary

- **License** (closes #110): docs were advertising MIT, but upstream `genogrove/genogrove` is GPL-3.0-or-later. Updated `source/index.md` License section and the `README.md` badge.
- **Registry API** (closes #108): rewrote `source/guide/data_types/registry.md` around the new dedup-on-insert API — `intern()`, `find()`, the `registry_value` concept (with a custom-type `std::hash` example), and a thread-safety section. Dropped the mutable `get()` example. Also updated `source/guide/serialization.md` to use `intern()` in the combined-persistence example.
- **performance.md** (closes #111): replaced the nonexistent `gst::unsorted` tag with the correct no-tag `insert_data(index, key, data)` form, and moved graph edges + external keys out of the "Not saved" list since `grove::serialize()` now persists them.

## Test plan

- [x] `make clean && make html` produces no new Sphinx warnings
- [x] Spot-check the rendered Registry page — new `registry_value` concept section, thread-safety section, and `intern()`/`find()` examples render cleanly
- [x] Spot-check the rendered License section on the index page (GPL-3.0 link resolves)
- [x] Spot-check `performance.md` Serialization note (graph edges listed under "saves", not "not saved")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project license from MIT to GPL v3.0 across all documentation files
  * Comprehensively rewrote registry documentation with updated API guidance, thread-safety information, and enhanced method documentation
  * Updated serialization examples to align with revised registry API patterns
  * Enhanced performance guide with clarification on insertion behavior and data persistence details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/docs/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->