### PR TITLE
v0.24.x docs catch-up: CLI reference + bed_entry/fasta_index notes + accuracy fixes

### DIFF
--- a/source/cli.md
+++ b/source/cli.md
@@ -6,67 +6,100 @@ The genogrove command-line interface provides tools for indexing and querying ge
 
 ### idx (Index)
 
-```{note}
-The `idx` subcommand is **not yet implemented**. The CLI accepts the
-arguments but `execute()` currently throws
-`std::runtime_error("Error: idx subcommand not yet implemented")`. The
-options listed below describe the planned interface — see the [tracking
-issue](https://github.com/genogrove/genogrove) for status.
-```
+Builds an index from a BED file and writes it to a zlib-compressed `.gg` index file — a
+serialized grove holding the BED records as `bed_entry` payloads. The index can later be searched
+directly with `isec -i`, avoiding a re-parse of the source BED file.
 
-Creates an index from an interval file for efficient queries.
-
-**Planned usage:**
+**Usage:**
 
 ```bash
 genogrove idx [OPTIONS] <inputfile>
 ```
 
-**Planned options:**
-
-- `-o, --outputfile <file>`: Specify output file (default: `<inputfile>.gg`)
-- `-k, --order <int>`: B+ tree order (default: 3)
-- `-s, --sorted`: Flag indicating intervals are pre-sorted
-- `-t, --timed`: Display indexing time
-
-### isec (Intersect)
-
-Finds overlapping intervals between query and target files.
-
-**Usage:**
-
-```bash
-genogrove isec -q <queryfile> -t <targetfile> [OPTIONS]
-```
-
 **Options:**
 
-- `-q, --queryfile <file>`: Query file (required)
-- `-t, --targetfile <file>`: Target file (required)
-- `-o, --outputfile <file>`: Output destination (default: stdout)
-- `-k, --order <int>`: B+ tree order (default: 3)
+- `-o, --outputfile <file>`: Output index file (default: `<inputfile>.gg`, written next to the input)
+- `-k, --order <int>`: B+ tree order (default: 3, minimum: 3)
+- `-s, --sorted`: Assert the input intervals are coordinate-sorted (enables the faster sorted-append path)
+- `-t, --timed`: Print the indexing time
 
 **Examples:**
 
 ```bash
-# Find overlaps between files
+# Build target.bed.gg next to the input file
+genogrove idx target.bed
+
+# Write the index to a specific path
+genogrove idx target.bed -o /data/target.gg
+
+# Pre-sorted input, with timing
+genogrove idx -s -t sorted.bed
+```
+
+```{note}
+Only BED input is currently supported (`.bed`, `.bed.gz`). GFF/GTF input is planned.
+```
+
+### isec (Intersect)
+
+Finds overlapping intervals between a query file and a target. The target can be built on the fly
+from a BED file (`-t`) or loaded from a prebuilt `.gg` index (`-i`).
+
+**Usage:**
+
+```bash
+genogrove isec -q <queryfile> (-t <targetfile> | -i <indexfile>) [OPTIONS]
+```
+
+**Options:**
+
+- `-q, --queryfile <file>`: Query BED file (required)
+- `-t, --targetfile <file>`: Target BED file to build the grove from
+- `-i, --indexfile <file>`: Prebuilt `.gg` index to search against
+- `-o, --outputfile <file>`: Output destination (default: stdout)
+- `-k, --order <int>`: B+ tree order used when building from `-t` (default: 3, minimum: 3)
+
+Either `-t` or `-i` must be supplied — at least one is required. When both are given, `-i` takes
+precedence and `-t` is ignored. `-k` only affects the grove built from `-t`; an index loaded via
+`-i` keeps the order it was created with.
+
+**Examples:**
+
+```bash
+# Find overlaps, building the target grove from a BED file
 genogrove isec -q regions.bed -t genes.bed
 
-# Write results to file
+# Search a prebuilt index instead of a BED file
+genogrove isec -q regions.bed -i genes.gg
+
+# Write results to a file
 genogrove isec -q regions.bed -t genes.bed -o overlaps.bed
 
-# Use higher tree order for large datasets
+# Use a higher tree order when building from a target
 genogrove isec -q regions.bed -t genes.bed -k 5
 
-# Handle compressed files
+# Compressed inputs are handled transparently
 genogrove isec -q regions.bed.gz -t genes.bed.gz
+```
+
+### Index-then-search workflow
+
+Build an index once, then reuse it across many queries:
+
+```bash
+# 1. Build the index from a target BED file
+genogrove idx genes.bed -o genes.gg
+
+# 2. Search the prebuilt index — no need to re-parse genes.bed
+genogrove isec -q regions.bed -i genes.gg
 ```
 
 ## Supported Formats
 
 Currently supported:
 
-- BED format (`.bed`, `.bed.gz`)
+- BED format (`.bed`, `.bed.gz`) — for query and target input
+- `.gg` index files (produced by `idx`) — for the `isec -i` search target
 
 Planned support:
 

--- a/source/cli.md
+++ b/source/cli.md
@@ -54,8 +54,8 @@ genogrove isec -q <queryfile> (-t <targetfile> | -i <indexfile>) [OPTIONS]
 **Options:**
 
 - `-q, --queryfile <file>`: Query BED file (required)
-- `-t, --targetfile <file>`: Target BED file to build the grove from
-- `-i, --indexfile <file>`: Prebuilt `.gg` index to search against
+- `-t, --targetfile <file>`: Target BED file to build the grove from (one of `-t` / `-i` required)
+- `-i, --indexfile <file>`: Prebuilt `.gg` index to search against (one of `-t` / `-i` required)
 - `-o, --outputfile <file>`: Output destination (default: stdout)
 - `-k, --order <int>`: B+ tree order used when building from `-t` (default: 3, minimum: 3)
 
@@ -88,9 +88,11 @@ Build an index once, then reuse it across many queries:
 
 ```bash
 # 1. Build the index from a target BED file
+#    Writes genes.gg and prints "Index written to genes.gg" on success.
 genogrove idx genes.bed -o genes.gg
 
 # 2. Search the prebuilt index — no need to re-parse genes.bed
+#    Writes overlapping BED records to stdout (use -o to redirect to a file).
 genogrove isec -q regions.bed -i genes.gg
 ```
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -42,6 +42,15 @@ breathe_show_include = False
 templates_path = ["_templates"]
 exclude_patterns = []
 
+# Breathe renders each Doxygen function declaration as a `cpp:function::`
+# directive using only the visible signature. C++20 `requires`-clause overloads
+# with identical signatures collapse to the same Sphinx declaration and trigger
+# a duplicate-declaration warning — e.g. `key<T, D>::key()` (requires
+# `default_initializable<D>`) and `key<T, void>::key()` (added in v0.24.4) both
+# read as `inline key ()`. Both declarations are correct upstream; the warning
+# is a tooling limitation.
+suppress_warnings = ["cpp.duplicate_declaration"]
+
 # MyST-Parser configuration
 source_suffix = {
     ".rst": "restructuredtext",

--- a/source/guide/data_types/registry.md
+++ b/source/guide/data_types/registry.md
@@ -190,7 +190,7 @@ for (const auto& entry : reader) {
 
 The serialized layout depends on whether `Key` and `Payload` are the same type:
 
-- **`Key == Payload`** (the default): `uint64_t count` followed by each payload via `serializer<Payload>`. This matches the historical format — **old `.ggx` files still load**.
+- **`Key == Payload`** (the default): `uint64_t count` followed by each payload via `serializer<Payload>`. This matches the historical format — **old `.gg` files still load**.
 - **`Key != Payload`**: `uint64_t count` followed by `(key, payload)` pairs in ID order. Requires both `serializer<Key>` and `serializer<Payload>` to be available.
 
 ### Failure semantics

--- a/source/guide/installation.md
+++ b/source/guide/installation.md
@@ -10,7 +10,7 @@ Before building genogrove, ensure you have:
   \- GCC 13 or newer
   \- Clang 16 or newer
   \- Apple Clang 15 or newer
-- **CMake 3.15 or higher**
+- **CMake 3.14 or higher**
 - **htslib** (for compressed file support)
   \- On Ubuntu/Debian: `sudo apt-get install libhts-dev`
   \- On macOS with Homebrew: `brew install htslib`
@@ -138,7 +138,7 @@ For development with debugging symbols and sanitizers:
 cmake -S . -B build-debug \
     -DCMAKE_BUILD_TYPE=Debug \
     -DBUILD_TESTING=ON \
-    -DENABLE_SANITIZERS=ON
+    -DENABLE_SANITIZER=ON
 cmake --build build-debug
 ```
 

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -669,8 +669,9 @@ for (const auto& entry : gff_reader) {
 
 **Notes:**
 
-- `fasta_index` throws `std::out_of_range` on unknown sequence names and `std::runtime_error` on
-  I/O or fetch failures.
+- `fasta_index::fetch` throws `std::out_of_range` on unknown sequence names and on invalid regions
+  (`start >= end`, or a region exceeding htslib's coordinate limit), and `std::runtime_error` only
+  on an actual htslib fetch failure.
 - The `.fai` file is created on first use if missing (requires write permission to the FASTA
   directory).
 - `fasta_index` is non-copyable and movable.

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -669,9 +669,10 @@ for (const auto& entry : gff_reader) {
 
 **Notes:**
 
-- `fasta_index::fetch` throws `std::out_of_range` on unknown sequence names and on invalid regions
-  (`start >= end`, or a region exceeding htslib's coordinate limit), and `std::runtime_error` only
-  on an actual htslib fetch failure.
+- All `fasta_index` lookup methods (`fetch`, `sequence_name`, `sequence_length`) throw
+  `std::out_of_range` on unknown sequence names or out-of-range indices; `fetch` additionally
+  throws `std::out_of_range` on invalid regions (`start >= end`, or a region exceeding htslib's
+  coordinate limit). `std::runtime_error` is reserved for an actual htslib fetch failure.
 - The `.fai` file is created on first use if missing (requires write permission to the FASTA
   directory).
 - `fasta_index` is non-copyable and movable.

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -189,6 +189,10 @@ struct genogrove::data_type::serialization_traits<ThirdPartyType> {
 - **Trivially copyable types** (`int`, `double`, `uint32_t`, etc.) — serialized via `memcpy`
 - **`std::string`** — built-in specialization (length-prefixed)
 - **Built-in key types** (`interval`, `genomic_coordinate`, `numeric`, `kmer`) — member methods provided
+- **`gio::bed_entry`** (with its nested `gio::block_info`) — member `serialize`/`deserialize` provided
+  as of v0.24.3, so a `grove<gdt::interval, gio::bed_entry>` can be persisted directly. The `.gg`
+  files produced by the `idx` CLI subcommand are this form. `gio::rgb_color` and `gio::thick_info`
+  are trivially copyable and serialize automatically.
 
 ## Source Stream Must Be Seekable for Concatenated Payloads
 
@@ -203,7 +207,7 @@ On non-seekable sources (pipes, sockets, custom non-seekable streambufs) the see
 
 > `inflate_streambuf: source stream is not seekable; concatenated payloads require a seekable source`
 
-For a single-payload `.ggx` file loaded via `std::ifstream`, this requirement is automatically
+For a single-payload `.gg` file loaded via `std::ifstream`, this requirement is automatically
 satisfied — file streams are seekable. The requirement matters only for the concatenated-payload
 pattern (registry then grove from the same stream, multiple grove payloads back-to-back, sentinel
 trailers).

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -189,8 +189,8 @@ struct genogrove::data_type::serialization_traits<ThirdPartyType> {
 - **Trivially copyable types** (`int`, `double`, `uint32_t`, etc.) — serialized via `memcpy`
 - **`std::string`** — built-in specialization (length-prefixed)
 - **Built-in key types** (`interval`, `genomic_coordinate`, `numeric`, `kmer`) — member methods provided
-- **`gio::bed_entry`** (with its nested `gio::block_info`) — member `serialize`/`deserialize` provided
-  as of v0.24.3, so a `grove<gdt::interval, gio::bed_entry>` can be persisted directly. The `.gg`
+- **`gio::bed_entry`** (with its nested `gio::block_info`) — member `serialize`/`deserialize`
+  provided, so a `grove<gdt::interval, gio::bed_entry>` can be persisted directly. The `.gg`
   files produced by the `idx` CLI subcommand are this form. `gio::rgb_color` and `gio::thick_info`
   are trivially copyable and serialize automatically.
 

--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,7 @@ Genogrove provides a specialized B+ tree data structure (the **grove**) optimize
 
 **Key Features:**
 
-- **Flexible Key Types**: Works with any type satisfying the `key_type_base` concept (built-in: `interval`, `genomic_coordinate`)
+- **Flexible Key Types**: Works with any type satisfying the `key_type_base` concept (built-in: `interval`, `genomic_coordinate`, `numeric`, `kmer`)
 - **Multi-Index Organization**: Separate trees per chromosome for efficient queries
 - **Sorted Insertion**: O(1) amortized insertion for pre-sorted genomic data
 - **Graph Overlay**: Link keys within the grove to represent feature relationships
@@ -83,7 +83,7 @@ int main() {
 ## Requirements
 
 - **Compiler**: C++20 compatible (GCC 13+, Clang 16+, Apple Clang 15+)
-- **Build System**: CMake 3.15 or higher
+- **Build System**: CMake 3.14 or higher
 - **Dependencies**: htslib (for compressed file support)
 
 ## Getting Started


### PR DESCRIPTION
## Summary

Bundles the docs catch-up for genogrove v0.24.x across CLI, serialization, I/O, and a few accuracy nits — all non-conflicting.

**CLI reference (#131, #132)** — `idx` is implemented as of v0.24.3, so the "not yet implemented" note and "planned" framing are replaced with actual usage, options, and examples. `isec` gains the `-i/--indexfile` option for searching a prebuilt `.gg` index, and `-t` is now optional (either `-t` or `-i` is required; `-i` takes precedence). Adds the index-then-search workflow.

**Serialization (#130, #136)** — `serialization.md` now notes that `gio::bed_entry` (with nested `block_info`) is a serializable grove payload as of v0.24.3, so `grove<interval, bed_entry>` can be persisted directly (this is the `.gg` form the `idx` CLI writes). Also fixes the `.ggx` → `.gg` extension references in `serialization.md` and `registry.md`.

**I/O (#129)** — `io.md` now reflects that `fasta_index::fetch` throws `std::out_of_range` for invalid regions (`start >= end`, or exceeding htslib's coordinate limit), with `std::runtime_error` reserved for actual fetch failures.

**Accuracy nits (#136, #137)** — `index.md` lists all four built-in key types (was missing `numeric`, `kmer`). `index.md` / `installation.md` corrected: CMake minimum is 3.14 (per `CMakeLists.txt`), not 3.15. Sanitizer CMake option is `ENABLE_SANITIZER` (singular), not the silently-ignored `ENABLE_SANITIZERS`.

**Not in this PR** — #135 (graph.md broken examples from the `query_result` const-pointer change) is closed in favour of the upstream revert tracked at genogrove/genogrove#435; once that lands the examples compile as-is with no doc change needed.

Closes #129.
Closes #130.
Closes #131.
Closes #132.
Closes #136.
Closes #137.

## Test plan

- [x] `make clean && make html` — confirm no new Sphinx build warnings
- [x] Visually check rendered pages: `cli.md` (idx/isec), `serialization.md` (bed_entry bullet + `.gg`), `io.md` (fasta_index Notes), `index.md`, `installation.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the `idx` subcommand for building compressed `.gg` indexes from BED input, with usage, options, timing and examples.
  * Expanded `isec` docs to support querying against on‑the‑fly targets or prebuilt `.gg` indexes; clarified option precedence, output behavior and examples (file/stdout, tree order, compressed BED).
  * Clarified supported formats (BED, BED.gz, `.gg`) and legacy `.gg` compatibility.
  * Added serialization notes (bed entries auto-serializable) and added `kmer` key type.
  * Lowered CMake minimum to 3.14 and fixed Debug build option name.
  * Clarified indexed-access fetch/error semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genogrove/docs/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->