### PR TITLE
Document the pygenogrove Python API

### DIFF
--- a/source/reference/index.md
+++ b/source/reference/index.md
@@ -20,7 +20,9 @@ The core C++ library provides high-performance genomic data structures and I/O u
 
 ## Python Library
 
-Python bindings for the C++ library (coming soon).
+`pygenogrove` — Python bindings for the C++ library: a strand-aware
+`GenomicCoordinate` key, a universal JSON-payload `Grove`, typed BED/GFF groves,
+a graph overlay, and file readers (BED/GFF/BAM/FASTA).
 
 {doc}`python/index`
 

--- a/source/reference/python/coordinates.md
+++ b/source/reference/python/coordinates.md
@@ -1,0 +1,68 @@
+# GenomicCoordinate
+
+`GenomicCoordinate` is the standard key type for every grove. It is a **stranded**
+genomic coordinate with closed `[start, end]` bounds (0-based, both endpoints
+inclusive).
+
+```python
+GenomicCoordinate(strand: str, start: int, end: int)
+```
+
+`strand` is one of `'+'`, `'-'`, `'.'`, `'*'`. Overlap requires **both**
+coordinate overlap **and** strand compatibility.
+
+```python
+import pygenogrove as pg
+
+gc = pg.GenomicCoordinate("+", 100, 200)
+gc.strand, gc.start, gc.end       # '+', 100, 200
+str(gc)                           # "+:100-200"
+```
+
+## Strand semantics
+
+| Strand | Meaning                                                    |
+| ------ | --------------------------------------------------------- |
+| `'+'`  | Forward strand                                            |
+| `'-'`  | Reverse strand                                            |
+| `'.'`  | A **concrete unstranded** value — matches only `'.'`      |
+| `'*'`  | A **wildcard** query strand — matches any strand          |
+
+The `'.'` vs `'*'` distinction trips people up: `'.'` is a real value that only
+matches other `'.'` coordinates, whereas `'*'` is a wildcard that matches
+everything. Plain unstranded intervals are just `GenomicCoordinate('.', start, end)`.
+
+```python
+import pygenogrove as pg
+g = pg.Grove()
+g.insert("chr1", pg.GenomicCoordinate("+", 100, 200))
+g.insert("chr1", pg.GenomicCoordinate("-", 100, 200))
+
+# strand-aware: only the '+' coordinate matches a '+' query
+len(g.intersect(pg.GenomicCoordinate("+", 150, 160), "chr1"))   # 1
+# a '*' wildcard query matches both strands
+len(g.intersect(pg.GenomicCoordinate("*", 150, 160), "chr1"))   # 2
+```
+
+## Sorting
+
+Sort order is **coordinate-first**: `start` → `end` → `strand`, with strand
+order `* < . < + < -`.
+
+## Attributes and methods
+
+**Attributes** (read-only): `strand`, `start`, `end`
+
+**Methods**:
+
+- `set_range(start, end)` / `set_strand(strand)` — **pre-insertion only**.
+- `GenomicCoordinate.overlaps(a, b)` — static, strand-aware overlap check.
+
+:::{warning}
+Do **not** mutate a coordinate after inserting it. `start`, `end`, and `strand`
+are read-only, and `set_range()` / `set_strand()` must only be used on
+coordinates you have **not** yet inserted (e.g. a query you want to reuse).
+Mutating a stored key silently corrupts B+ tree ordering. Note that `key.value`
+returns the coordinate **by copy**, so reading it back from a grove is always
+safe.
+:::

--- a/source/reference/python/graph.md
+++ b/source/reference/python/graph.md
@@ -1,0 +1,107 @@
+# Graph overlay
+
+Every grove carries an embedded **graph overlay** — directed edges between keys —
+on top of its spatial B+ tree index. This lets you represent feature
+relationships (exon→transcript, regulatory links, …) alongside interval queries.
+
+## Edges between keys
+
+```python
+import pygenogrove as pg
+
+g = pg.Grove()
+a = g.insert("chr1", pg.GenomicCoordinate("+", 100, 200))
+b = g.insert("chr1", pg.GenomicCoordinate("+", 300, 400))
+g.add_edge(a, b)
+g.has_edge(a, b)            # True
+g.get_neighbors(a)         # [b]
+g.out_degree(a)            # 1
+```
+
+- `add_edge(source: Key, target: Key)` — add a directed edge. Raises `ValueError`
+  if either key is `None`.
+- `remove_edge(source: Key, target: Key) -> bool` — remove an edge; `True` if one
+  was removed.
+- `has_edge(source: Key, target: Key) -> bool` — test whether an edge exists.
+- `get_neighbors(source: Key) -> list[Key]` — keys directly reachable from `source`.
+- `out_degree(source: Key) -> int` — number of outgoing edges from `source`.
+- `edge_count() -> int` — total edges in the overlay.
+- `vertex_count_with_edges() -> int` — keys with at least one outgoing edge.
+
+:::{note}
+`add_edge` does **not** deduplicate — calling it twice creates parallel edges.
+:::
+
+## External keys
+
+`add_external_key(key: GenomicCoordinate, data=None) -> Key` adds a graph-only key
+that lives **outside** the B+ tree index: it participates in the graph but is
+**not** returned by `intersect()`. Useful for anchoring graph nodes that are not
+themselves query targets.
+
+```python
+ext = g.add_external_key(pg.GenomicCoordinate(".", 0, 0), {"label": "promoter"})
+g.add_edge(ext, a)
+```
+
+External keys are **not** invalidated by `compact()` (unlike indexed keys — see
+{doc}`grove`).
+
+## Labelled edges
+
+On the **universal `Grove`**, edges carry a JSON-serializable payload. (The typed
+`BedGrove` / `GffGrove` keep unlabelled edges for binary interop, so the
+labelled-edge methods below are absent there — see {doc}`typed_groves`.)
+
+```python
+import pygenogrove as pg
+
+g = pg.Grove()
+a = g.insert("chr1", pg.GenomicCoordinate("+", 100, 200))
+b = g.insert("chr1", pg.GenomicCoordinate("+", 300, 400))
+g.add_edge(a, b, {"type": "exon->transcript", "weight": 7})
+g.get_edges(a)                                    # [{"type": ..., "weight": 7}]
+g.get_neighbors_if(a, lambda m: m["weight"] > 5)  # [b]
+```
+
+- `add_edge(source, target, data)` — add an edge with a metadata payload. The
+  2-argument `add_edge` attaches `None`.
+- `get_edges(source: Key) -> list` — the edge payloads of `source`'s outgoing
+  edges, parallel to `get_neighbors(source)`.
+- `get_neighbors_if(source: Key, predicate) -> list[Key]` — target keys whose edge
+  metadata satisfies `predicate(metadata)`. The predicate receives the **decoded**
+  payload (edges added without a payload yield `None`, so guard for it when mixing
+  labelled and unlabelled edges).
+- `link_with(keys: list[Key], predicate)` — label adjacent pairs: `predicate(k1, k2)`
+  returns the edge payload to attach, or `None` to skip.
+
+A canonical example is labelling exon→transcript edges with their intron gaps via
+`link_with` over a chromosome's exon keys.
+
+## Edge cleanup and bulk linking
+
+Available on **every** grove (universal and typed):
+
+- `remove_edges_from(source: Key) -> int` — remove outgoing edges; returns the count.
+- `remove_edges_to(target: Key) -> int` — remove incoming edges; returns the count.
+- `remove_all_edges(key: Key) -> int` — remove all edges touching `key`; returns the count.
+- `clear_graph()` — remove all edges (keys are left intact).
+- `graph_empty() -> bool` — whether the overlay has no edges.
+- `link_if(keys: list[Key], predicate)` — add an **unlabelled** edge between each
+  adjacent pair `(keys[i], keys[i+1])` for which `predicate(k1, k2)` returns
+  `True` (typically over the keys returned by a bulk insert).
+
+:::{note}
+**Not yet exposed:** `remove_edges_if`
+([pygenogrove#33](https://github.com/genogrove/pygenogrove/issues/33)) and SIF
+export `grove_to_sif`
+([pygenogrove#34](https://github.com/genogrove/pygenogrove/issues/34)).
+:::
+
+## Persistence
+
+`serialize` / `deserialize` round-trip the graph overlay along with the
+coordinates and payloads. An edge-bearing universal-`Grove` `.gg` stores per-edge
+JSON metadata and is read in C++ as
+`grove<genomic_coordinate, std::string, std::string>` (edgeless files are
+unchanged). See {doc}`grove` for the serialization API.

--- a/source/reference/python/grove.md
+++ b/source/reference/python/grove.md
@@ -1,0 +1,157 @@
+# Grove
+
+The universal `Grove` is `grove<genomic_coordinate, json>`: a B+ tree keyed by
+{doc}`coordinates` that stores any JSON-serializable payload (dict / list /
+scalar / `None`) per key. Each key may carry a **different** shape — no schema is
+enforced.
+
+```python
+Grove(order: int = 3)
+```
+
+- `order` — maximum branching factor (max keys per node = `order - 1`). Minimum 3.
+  Higher orders (100–500) reduce tree height for large datasets.
+
+Groves support **multiple indices** (typically one per chromosome): the first
+argument to `insert` / `intersect` selects the index.
+
+## Inserting and querying
+
+```python
+import pygenogrove as pg
+
+g = pg.Grove()
+g.insert("chr1", pg.GenomicCoordinate("+", 100, 200), {"gene": "FOO"})
+g.insert("chr1", pg.GenomicCoordinate(".", 300, 400))   # no payload -> None
+
+hit = list(g.intersect(pg.GenomicCoordinate("+", 150, 160), "chr1"))[0]
+hit.value, hit.data        # GenomicCoordinate('+', 100, 200), {'gene': 'FOO'}
+```
+
+**Methods**:
+
+- `insert(index: str, key: GenomicCoordinate, data=None) -> Key` — insert a
+  coordinate with an optional JSON-serializable payload at the given index.
+- `intersect(query: GenomicCoordinate) -> QueryResult` — strand-aware overlaps
+  across **all** indices.
+- `intersect(query: GenomicCoordinate, index: str) -> QueryResult` — overlaps in
+  a **specific** index (faster; prefer this when you know the chromosome).
+- `len(grove)` / `size()` / `indexed_vertex_count()` — number of indexed
+  intervals across all indices.
+- `get_order()` — the tree's branching factor.
+
+## Key
+
+A `Key` is a wrapper for a coordinate stored in the grove. It is returned by
+inserts and yielded by query results, and it keeps its owning `Grove` alive.
+
+**Attributes**:
+
+- `value` — the `GenomicCoordinate`, returned **by copy** (mutating it cannot
+  corrupt ordering).
+- `data` — the payload. On the universal `Grove` this is the JSON value you
+  stored, returned as a freshly decoded copy on each access.
+
+:::{note}
+`Key` objects are only valid while their owning `Grove` is alive. The bindings
+keep the `Grove` alive for as long as you hold a `Key`, but keys cannot be
+pickled or carried across groves.
+:::
+
+## QueryResult
+
+The object returned by `intersect`.
+
+**Attributes**: `query` (the query coordinate), `keys` (the matching keys).
+
+**Methods**: `__len__()` (number of results), `__iter__()` (iterate the keys).
+
+## Flanking (nearest neighbours)
+
+`flanking` finds the nearest **non-overlapping** keys on either side of a query.
+
+```python
+flanking(query: GenomicCoordinate, index: str) -> FlankingResult
+```
+
+**FlankingResult**:
+
+- `predecessor` — the closest key entirely **before** the query (a `Key`), or `None`.
+- `successor` — the closest key entirely **after** the query (a `Key`), or `None`.
+
+Keys overlapping the query are excluded; for nested intervals the predecessor is
+the one with the largest end (smallest gap). Compute a gap distance from the
+returned key, e.g. `query.start - result.predecessor.value.end - 1` (closed
+coordinates).
+
+### Predicate-filtered flanking
+
+A third argument filters candidates with a Python callable
+`is_compatible(candidate, query) -> bool` applied at each leaf candidate; only
+keys for which it returns `True` are considered. The headline use is the nearest
+neighbour **on the same strand**:
+
+```python
+import pygenogrove as pg
+g = pg.Grove()
+g.insert("chr1", pg.GenomicCoordinate("+", 100, 200))
+g.insert("chr1", pg.GenomicCoordinate("-", 300, 400))   # opposite strand, nearer
+
+q = pg.GenomicCoordinate("+", 500, 510)
+# Without the predicate, the nearer '-' key would be the predecessor.
+# A same-strand predicate skips it -> nearest '+' neighbour:
+r = g.flanking(q, "chr1", lambda cand, q: cand.strand == q.strand)
+r.predecessor.value         # GenomicCoordinate('+', 100, 200)
+```
+
+- The predicate receives the key **values** (e.g. `GenomicCoordinate`); for the
+  typed groves it receives the interval value.
+- Predicate exceptions propagate to Python; the call holds the GIL.
+
+## Removal and storage
+
+- `remove_key(index: str, key: Key) -> bool` — remove a key from the index's B+
+  tree (rebalancing as needed) and drop every graph edge touching it. Returns
+  `True` if found; a `None` key or unknown index returns `False`. The key remains
+  as a **dead storage slot** until `compact()`.
+- `compact() -> None` — reclaim the dead slots left by `remove_key()`.
+- `vertex_count()` — indexed + external keys.
+- `external_vertex_count()` — external keys only (see {doc}`graph`).
+- `key_storage_size()` — total storage slots (live + B+ tree separators + dead slots).
+
+:::{warning}
+**`compact()` invalidates indexed `Key` handles.** It moves key storage, so every
+previously-returned indexed `Key` (from `insert` / `insert_bulk` / `intersect` /
+`flanking`) becomes invalid and must not be used afterward — re-discover keys via
+a fresh query. Keys from `add_external_key()` are unaffected.
+:::
+
+```python
+import pygenogrove as pg
+g = pg.Grove()
+k = g.insert("chr1", pg.GenomicCoordinate(".", 100, 200))
+g.remove_key("chr1", k)        # True; edges to/from k are also removed
+g.key_storage_size()           # still counts the dead slot
+g.compact()                    # reclaims it — k (and all old indexed Keys) now invalid
+# Re-query to get fresh, valid handles:
+for key in g.intersect(pg.GenomicCoordinate("*", 0, 10**6), "chr1"):
+    ...
+```
+
+## Serialization
+
+Groves persist to a zlib-compressed `.gg` binary.
+
+- `serialize(path: str)` — write the grove (coordinates + payloads + graph
+  overlay) to `path`.
+- `deserialize(path: str) -> Grove` *(static)* — load a grove written by `serialize`.
+
+```python
+g.serialize("out.gg")
+reloaded = pg.Grove.deserialize("out.gg")
+```
+
+An edgeless universal-`Grove` `.gg` stores its payload as **JSON text**, so it is
+readable by a C++ `grove<genomic_coordinate, std::string>`. With labelled edges
+(see {doc}`graph`) the C++ interop type is
+`grove<genomic_coordinate, std::string, std::string>`.

--- a/source/reference/python/index.md
+++ b/source/reference/python/index.md
@@ -1,18 +1,90 @@
 # Python API Reference
 
-Python bindings for the genogrove C++ library.
+`pygenogrove` provides Python bindings for the genogrove C++ library — a B+ tree
+optimized for storing and querying genomic intervals, with an embedded graph
+overlay for feature relationships.
 
-:::{note}
-Python bindings are currently under development.
-:::
+```{toctree}
+:caption: Python API
+:maxdepth: 2
 
-## Coming Soon
+coordinates
+grove
+graph
+typed_groves
+io
+registry
+```
 
-The Python API will provide:
+## Installation
 
-- Pythonic interface to genogrove data structures
-- Integration with NumPy and Pandas
-- Easy-to-use file readers for BED, GFF, and other formats
-- Efficient genomic interval operations
+```bash
+pip install pygenogrove
+```
 
-Check back soon or watch the [GitHub repository](https://github.com/genogrove/genogrove) for updates.
+Building from source requires a C++20 compiler, CMake 3.15+, and Python 3.8+:
+
+```bash
+git clone --recursive https://github.com/genogrove/pygenogrove.git
+cd pygenogrove
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+## Quick start
+
+The standard key is a **`GenomicCoordinate`** (stranded, 0-based closed
+`[start, end]`), and the standard **`Grove`** stores any JSON-serializable
+payload (dict / list / scalar / `None`) per key:
+
+```python
+import pygenogrove as pg
+
+grove = pg.Grove()
+
+# Insert stranded coordinates with arbitrary metadata (or no data at all)
+grove.insert("chr1", pg.GenomicCoordinate("+", 100, 200), {"gene": "FOO", "score": 5})
+grove.insert("chr1", pg.GenomicCoordinate("-", 100, 200), {"gene": "BAR"})
+grove.insert("chr1", pg.GenomicCoordinate(".", 300, 400))   # data defaults to None
+
+# Query is strand-aware: a '+' query matches only '+' (and '*' wildcards)
+for key in grove.intersect(pg.GenomicCoordinate("+", 150, 160), "chr1"):
+    print(key.value, key.data)        # GenomicCoordinate('+', 100, 200) {'gene': 'FOO', 'score': 5}
+
+# '*' matches any strand; '.' is a concrete unstranded value (matches only '.')
+len(grove.intersect(pg.GenomicCoordinate("*", 150, 160), "chr1"))   # 2
+
+grove.serialize("out.gg")             # JSON-text payload; a C++ grove<gc, string> can read it
+```
+
+The payload round-trips transparently (no `json` import needed), and each key
+may carry a **different** shape — no schema is enforced.
+
+## Checking your version
+
+`pygenogrove` exposes two module-level version attributes that move on
+**independent cadences** — the binding package versions on its own surface
+maturity, while `__genogrove_version__` advertises the bound C++ library. When
+filing a bug, report **both**:
+
+```python
+import pygenogrove as pg
+print(pg.__version__)             # the pygenogrove package version, e.g. "0.5.0"
+print(pg.__genogrove_version__)   # the genogrove C++ library it was built against, e.g. "0.24.6"
+```
+
+## Coordinate systems
+
+Three coordinate conventions appear in the API. Convert deliberately when
+building grove keys from file records:
+
+| Type               | Convention                   | Example for the same locus |
+| ------------------ | ---------------------------- | -------------------------- |
+| `GenomicCoordinate` | 0-based **closed** `[start, end]`     | `(., 1000, 1999)` |
+| `BedEntry`          | 0-based **half-open** `[start, end)`  | `(chr1, 1000, 2000)` |
+| `GffEntry`          | 1-based **inclusive** `[start, end]`  | `(chr1, 1001, 2000)` |
+
+When loading records from a reader, prefer the entry-deriving inserts on the
+typed groves (`g.insert(index, entry)`) — they derive the closed
+`GenomicCoordinate` key from a record's native coordinates so you never
+hand-convert. See {doc}`typed_groves`.

--- a/source/reference/python/io.md
+++ b/source/reference/python/io.md
@@ -1,0 +1,167 @@
+# File readers and I/O
+
+`pygenogrove` ships single-pass iterators for the common genomic file formats,
+plus random-access FASTA and a format detector. Plain and gzip/BGZF-compressed
+(`.gz`) inputs are auto-detected.
+
+:::{note}
+The readers are **single-pass** — each owns an htslib file handle and cannot be
+restarted or iterated twice.
+:::
+
+## BedReader / GffReader
+
+`BedReader` and `GffReader` iterate BED and GFF3/GTF files, yielding `BedEntry` /
+`GffEntry` records (see {doc}`typed_groves`).
+
+```python
+import pygenogrove as pg
+
+for entry in pg.BedReader("peaks.bed"):
+    print(entry.chrom, entry.start, entry.end, entry.name)
+
+# The common workflow: load a file into a typed grove. The 2-argument insert
+# derives the grove's 0-based closed GenomicCoordinate key from each entry's
+# native coordinates, so you don't hand-convert.
+g = pg.BedGrove(256)
+for e in pg.BedReader("peaks.bed"):
+    g.insert(e.chrom, e)
+
+gff = pg.GffGrove(256)
+for e in pg.GffReader("genes.gff3"):
+    gff.insert(e.seqid, e)
+
+# bulk-load one chromosome at a time (insert_bulk is per-index):
+g2 = pg.BedGrove(256)
+g2.insert_bulk("chr1", [e for e in pg.BedReader("peaks.bed") if e.chrom == "chr1"])
+```
+
+```python
+BedReader(path: str, skip_invalid_lines: bool = False)
+GffReader(path: str, skip_invalid_lines: bool = False, validate_gtf: bool = False)
+```
+
+- A missing/unreadable `path` raises on construction.
+- With `skip_invalid_lines=False` (default) a malformed line raises `RuntimeError`
+  mid-iteration; with `True` such lines are skipped. The **first** data record is
+  validated when the reader is constructed, so a malformed first record raises
+  immediately regardless of this flag.
+- `GffReader(..., validate_gtf=True)` enforces the mandatory GTF2 attributes
+  (`gene_id`, `transcript_id`).
+- Both expose `get_error_message()` and `get_current_line()` for diagnostics.
+
+## BamReader (SAM/BAM alignments)
+
+`BamReader` iterates SAM/BAM files (htslib auto-detects the format) yielding
+`SamEntry` records, with filtering applied during iteration.
+
+```python
+import pygenogrove as pg
+
+for aln in pg.BamReader("reads.bam", min_mapq=30):
+    print(aln.qname, aln.chrom, aln.start, aln.end, aln.get_strand())
+
+# load alignments into the universal Grove (sam_entry isn't serializable, so
+# there is no typed BamGrove — route through to_coordinate() + to_dict())
+g = pg.Grove(256)
+for aln in pg.BamReader("reads.bam"):
+    if aln.is_mapped():
+        g.insert(aln.chrom, aln.to_coordinate(), aln.to_dict())
+```
+
+```python
+BamReader(path, skip_unmapped=True, skip_secondary=False,
+          skip_supplementary=False, skip_qc_fail=False,
+          skip_duplicates=False, min_mapq=0)
+```
+
+- **`SamEntry`** fields: `qname`, `chrom`, `start`, `end` (0-based half-open),
+  `mapq`, `sequence`, `quality`, `cigar` (string form), `flags` (an
+  `AlignmentFlags`). Helpers: `get_strand()`, `is_primary()` / `is_mapped()` /
+  `is_reverse()` / `is_secondary()` / `is_supplementary()` / `is_duplicate()` /
+  `is_paired()` / …, `consumes_reference()`, `has_flag(flag)`.
+- **`SamEntry.to_coordinate()`** derives the strand-aware `GenomicCoordinate` key
+  (strand from FLAG; half-open `[start, end)` → closed `[start, end-1]`; raises for
+  unmapped reads).
+- **`SamEntry.to_dict()`** is a convenient JSON payload of the core fields.
+- **`SamFlags`** exposes the standard FLAG bit constants; **`AlignmentFlags`** (the
+  `.flags` object) has `value()` plus the same `is_*()` predicates.
+
+:::{note}
+CIGAR element detail (the op/length list), paired-end mate info, auxiliary tags,
+and CRAM are not yet exposed.
+:::
+
+## FastaReader (FASTA/FASTQ sequences)
+
+`FastaReader` iterates FASTA/FASTQ files yielding `FastaEntry` records. Sequences
+are **named records, not intervals**, so this reader is standalone (no grove
+integration).
+
+```python
+import pygenogrove as pg
+
+for rec in pg.FastaReader("genome.fa"):
+    print(rec.name, rec.comment, len(rec))
+
+for rec in pg.FastaReader("reads.fq"):
+    print(rec.name, rec.sequence, rec.quality)   # is_fastq() -> True
+```
+
+```python
+FastaReader(path, skip_empty_sequences=False)
+```
+
+- **`FastaEntry`** fields: `name`, `comment`, `sequence`, `quality`
+  (`Optional[str]` — set for FASTQ, `None` for FASTA); `is_fastq()`,
+  `len(entry)` = sequence length. Constructible as `FastaEntry(name, sequence)`.
+
+## FastaIndex (random-access FASTA)
+
+`FastaIndex` provides random-access region fetches over a FASTA file, backed by an
+`.fai` index (built on first open — the directory must be writable then). It pairs
+with `FastaReader`: one streams, the other is random-access.
+
+```python
+import pygenogrove as pg
+
+fa = pg.FastaIndex("genome.fa")
+fa.fetch("chr1", 1000, 2000)   # bases of the 0-based half-open region [1000, 2000)
+fa.fetch("chrM")               # the whole sequence
+fa.sequence_length("chr1")     # length in bases
+list(fa.names()), "chr1" in fa, len(fa)
+
+# fetch a feature's bases: GenomicCoordinate is closed, fetch is half-open
+gc = pg.GenomicCoordinate("+", 4, 7)
+fa.fetch("chr1", gc.start, gc.end + 1)
+```
+
+- Methods: `fetch(name, start, end)` / `fetch(name)`, `sequence_count()`,
+  `sequence_name(i)`, `sequence_length(name)`, `has_sequence(name)`, plus the
+  Pythonic `len()` / `in` / `names()`.
+- Unknown name / invalid region raise `IndexError`.
+
+:::{important}
+**Coordinate pairing:** `FastaIndex.fetch` is half-open `[start, end)` while a
+`GenomicCoordinate` is closed `[start, end]`. Fetch a feature's bases with
+`idx.fetch(name, gc.start, gc.end + 1)`, where `name` is the chromosome / grove
+index (a `GenomicCoordinate` carries strand + start + end, not the chromosome).
+:::
+
+## FiletypeDetector (format detection)
+
+`FiletypeDetector` infers a file's format and compression from its extension
+(compression extension stripped first) and magic bytes.
+
+```python
+import pygenogrove as pg
+
+ftype, comp = pg.FiletypeDetector().detect_filetype("peaks.bed.gz")
+# (Filetype.BED, CompressionType.GZIP)
+```
+
+- `detect_filetype(path) -> (Filetype, CompressionType)`
+- `Filetype`: `BED` / `BEDGRAPH` / `GFF` / `GTF` / `VCF` / `SAM` / `BAM` /
+  `FASTA` / `FASTQ` / `GG` / `UNKNOWN`.
+- `CompressionType`: `NONE` / `GZIP` / `BZIP2` / `XZ` / `ZSTD` / `LZ4` /
+  `UNKNOWN`.

--- a/source/reference/python/registry.md
+++ b/source/reference/python/registry.md
@@ -1,0 +1,35 @@
+# StringRegistry
+
+`StringRegistry` exposes genogrove's `registry<std::string>` — a process-wide
+**string-interning singleton** that maps distinct strings to small, stable integer
+ids (deduplicated). Handy for interning chromosome names, sources, gene ids, etc.
+
+```python
+import pygenogrove as pg
+
+r = pg.StringRegistry.instance()
+a = r.intern("chr1")     # 0
+b = r.intern("chr1")     # 0  (deduplicated -> same id)
+r.get(a)                 # "chr1"
+r.find("chr2")           # None (lookup without inserting)
+r.serialize("names.gg")
+```
+
+## Surface
+
+- `StringRegistry.instance()` — the singleton.
+- `intern(value: str) -> int` — idempotent (same value → same id).
+- `find(value: str) -> int | None` — lookup without inserting.
+- `get(id: int) -> str` — raises `IndexError` on an invalid id.
+- `contains(id)`, `size()` / `len(r)`, `empty()`, `clear()`, `StringRegistry.reset()`.
+- `StringRegistry.null_id` (= `2**32 − 1`).
+- `serialize(path)` / `StringRegistry.deserialize(path)` — binary; `deserialize`
+  loads into the singleton, **replacing** current data.
+
+:::{note}
+It is a **singleton** — one global pool per process. Use `reset()` / `clear()` to
+wipe it (e.g. between runs or tests).
+
+The underlying binding is generic, but only the `std::string` instantiation is
+exposed today. Tagged pools and the key→payload metadata form are not yet bound.
+:::

--- a/source/reference/python/typed_groves.md
+++ b/source/reference/python/typed_groves.md
@@ -1,0 +1,168 @@
+# Typed groves (BED / GFF)
+
+The schemaless {doc}`grove` is the everyday tool. The **typed** groves
+`BedGrove` (`grove<genomic_coordinate, bed_entry>`) and `GffGrove`
+(`grove<genomic_coordinate, gff_entry>`) are the alternative for when you want a
+**guaranteed BED/GFF schema** and full interop with typed C++ `.gg` files: instead
+of a JSON payload, each key carries a structured `BedEntry` / `GffEntry`.
+
+Both are genomic-coordinate keyed and expose the same surface as `Grove`
+(multi-index `insert` / `intersect`, the graph overlay, `serialize` /
+`deserialize`), with the differences noted below.
+
+## BedGrove
+
+```python
+import pygenogrove as pg
+
+g = pg.BedGrove(100)
+
+# insert(index, coord, data) — the GenomicCoordinate is the key, BedEntry is the payload
+entry = pg.BedEntry("chr1", 1000, 2000)   # BED-native coords (0-based, half-open)
+entry.name = "BRCA1"
+entry.score = 900
+entry.strand = "+"
+key = g.insert("chr1", pg.GenomicCoordinate(".", 1000, 1999), entry)
+
+print(key.value.start, key.data.name)     # 1000 BRCA1
+
+for hit in g.intersect(pg.GenomicCoordinate(".", 1500, 1600), "chr1"):
+    print(hit.data.name, hit.data.score)
+
+g.serialize("genes.gg")
+reloaded = pg.BedGrove.deserialize("genes.gg")   # preserves the BedEntry data
+```
+
+Differences from the universal `Grove`:
+
+- `insert(index: str, key: GenomicCoordinate, data: BedEntry) -> BedKey` takes the
+  BED payload.
+- `add_external_key(key: GenomicCoordinate, data: BedEntry) -> BedKey` takes the
+  payload too.
+- Typed groves keep **unlabelled** graph edges (for binary C++ interop), so the
+  labelled-edge methods (`add_edge(s, t, data)`, `get_edges`, `get_neighbors_if`,
+  `link_with`) are **absent**. Plain edges and all edge-cleanup methods are
+  present — see {doc}`graph`.
+
+`GffGrove` is identical with a `GffEntry` payload.
+
+### Entry-deriving inserts
+
+The foolproof way to load records from a reader — pass a bare entry and the
+`GenomicCoordinate` key is derived from its native coordinates (no
+hand-conversion):
+
+- `insert(index, entry) -> BedKey` — a 2-argument overload. BED's half-open
+  `[s, e)` → closed `[s, e-1]`; GFF's 1-based `[s, e]` → `[s-1, e-1]`. Strand is
+  taken from the record's strand column (absent → `'.'`).
+- `insert_bulk(index, entries, presorted=False) -> list[BedKey]` — same idea for a
+  whole list of bare entries.
+
+```python
+g = pg.BedGrove(256)
+for e in pg.BedReader("peaks.bed"):
+    g.insert(e.chrom, e)        # key derived from each entry
+```
+
+### Fast-path inserts
+
+Data-carrying groves also expose explicit fast paths:
+
+- `insert_sorted(index, coord, data) -> BedKey` — single insert on the
+  rightmost-append path (skips tree traversal).
+- `insert_bulk(index, items, presorted=False) -> list[BedKey]` — insert many
+  explicit `(GenomicCoordinate, BedEntry)` records at once (10–20× faster for
+  large datasets; an empty index is built bottom-up in O(n)). `presorted=True`
+  skips the internal sort.
+
+:::{warning}
+**Precondition:** sorted/bulk inserts require ascending intervals, and when
+appending to a non-empty index every new interval must be greater than all
+existing ones. Violating this corrupts B+ tree ordering — use plain `insert` if
+unsure.
+:::
+
+### BedKey
+
+Like `Key`, but adds a `data` attribute:
+
+- `value` — the interval, returned **by copy** (do not rely on mutating it).
+- `data` — the associated `BedEntry`, a **live, mutable** reference. Unlike
+  `value`, the payload is not part of the B+ tree ordering, so editing it in place
+  is safe.
+
+`BedQueryResult` is the `BedGrove` analog of `QueryResult` (its keys are `BedKey`s).
+
+## BedEntry
+
+A single BED record. Coordinates are BED-native: 0-based, half-open
+`[start, end)` (distinct from the closed `[start, end]` of the `GenomicCoordinate`
+key).
+
+```python
+BedEntry(chrom: str, start: int, end: int)
+```
+
+**Attributes** (read/write):
+
+- `chrom` (str), `start` (int), `end` (int)
+- `name` — `Optional[str]` (BED4+)
+- `score` — `Optional[int]` (BED5+)
+- `strand` — `Optional[str]`, a single character (`'+'`, `'-'`, `'.'`). Assigning
+  an empty or multi-character string raises `ValueError`; `None` clears it (BED6+).
+- `thickness` — `Optional[ThickInfo]` (BED7+)
+- `item_rgb` — `Optional[RgbColor]` (BED9+)
+- `blocks` — `Optional[BlockInfo]` (BED12)
+
+Supporting value types: `ThickInfo(start, end)`, `RgbColor(red, green, blue)`
+(channels 0–255), and `BlockInfo(count, sizes, starts)` (with `list[int]`
+`sizes`/`starts`). List fields are returned/assigned by copy.
+
+## GffGrove
+
+The same typed grove for **GFF3/GTF** records — identical surface to `BedGrove`,
+with a `GffEntry` payload:
+
+```python
+import pygenogrove as pg
+
+g = pg.GffGrove(100)
+
+entry = pg.GffEntry("chr1", 1000, 2000, "gene")   # GFF-native coords (1-based, inclusive)
+entry.source = "ensembl"
+entry.strand = "+"
+entry.attributes = {"gene_id": "ENSG1", "gene_name": "BRCA1"}
+key = g.insert("chr1", pg.GenomicCoordinate(".", 999, 1999), entry)
+
+print(key.data.type, key.data.get_gene_id())      # gene ENSG1
+
+g.serialize("genes.gg")
+reloaded = pg.GffGrove.deserialize("genes.gg")
+```
+
+`GffKey` mirrors `BedKey` (`value` is a copy, `data` is a live mutable `GffEntry`
+reference); `GffQueryResult` is the `GffGrove` analog of `QueryResult`.
+
+## GffEntry
+
+A single GFF3/GTF record. Coordinates are GFF-native: **1-based, both endpoints
+inclusive**.
+
+```python
+GffEntry(seqid: str, start: int, end: int, type: str)
+```
+
+**Attributes** (read/write):
+
+- `seqid` (str), `source` (str), `type` (str), `start` (int), `end` (int)
+- `score` — `Optional[float]`
+- `strand` — `Optional[str]`, a single character (`'+'`, `'-'`, `'.'`, `'?'`);
+  empty or multi-character raises `ValueError`, `None` clears it.
+- `phase` — `Optional[int]` (CDS phase 0/1/2)
+- `attributes` — `dict[str, str]`, the column-9 key/value pairs (returned/assigned
+  by copy)
+- `format` — a `GffFormat` enum (`GFF3` / `GTF` / `UNKNOWN`)
+
+**Methods**: `is_gtf()`, `is_gff3()`, `get_attribute(key)`, and the GTF helpers
+`get_gene_id()`, `get_transcript_id()`, `get_exon_number()`, `get_gene_name()`,
+`get_gene_biotype()` (each returns `None` when the attribute is absent).


### PR DESCRIPTION
Replaces the Python reference placeholder with a full reference for the
**pygenogrove** Python bindings, reflecting the current v0.5.0 surface and the
0.4.0+ genomics-first redesign (`GenomicCoordinate` is the standard strand-aware
key; the universal `Grove` stores JSON payloads).

## New pages (`source/reference/python/`)

- **coordinates.md** — `GenomicCoordinate` key + strand semantics (`*` wildcard vs `.` unstranded), sort order
- **grove.md** — universal JSON `Grove`: insert/intersect, `Key`/`QueryResult`, predicate-filtered `flanking`, `remove_key`/`compact` + vertex/storage counts, serialization
- **graph.md** — graph overlay: edges, external keys, labelled edges (`add_edge(s,t,data)`/`get_edges`/`get_neighbors_if`/`link_with`), edge cleanup + bulk linking
- **typed_groves.md** — `BedGrove`/`GffGrove` + `BedEntry`/`GffEntry`, entry-deriving and fast-path bulk inserts
- **io.md** — `BedReader`/`GffReader`/`BamReader`/`FastaReader`, `FastaIndex`, `FiletypeDetector`
- **registry.md** — `StringRegistry` interning singleton
- **index.md** — overview, install, `__version__`/`__genogrove_version__`, quick start, coordinate-systems table

Also updates `reference/index.md` to drop the "coming soon" framing for the Python library.

Content is sourced from the pygenogrove README/bindings (v0.5.0, built against genogrove v0.24.6).

## Resolves

Closes #148
Closes #149
Closes #150
Closes #151
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156
Closes #157
Closes #158
Closes #159
Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)