### PR TITLE
Document v0.24.7 features: VCF reader, .gg header, GFF/links CLI, dataless grove, parallel edges, SIF

### DIFF
--- a/source/cli.md
+++ b/source/cli.md
@@ -6,9 +6,15 @@ The genogrove command-line interface provides tools for indexing and querying ge
 
 ### idx (Index)
 
-Builds an index from a BED file and writes it to a zlib-compressed `.gg` index file — a
-serialized grove holding the BED records as `bed_entry` payloads. The index can later be searched
-directly with `isec -i`, avoiding a re-parse of the source BED file.
+Builds an index from a BED or GFF/GTF file and writes it to a zlib-compressed `.gg` index file — a
+serialized grove holding the records as payloads. The index can later be searched directly with
+`isec -i`, avoiding a re-parse of the source file.
+
+The input file type is detected automatically and determines the grove type written:
+
+- BED → `grove<interval, bed_entry>`, stored with `.gg` payload_type `0x01` (BED)
+- GFF3/GTF → `grove<interval, gff_entry>`, stored with `.gg` payload_type `0x02` (GFF)
+- anything else → error `"unsupported input format"`
 
 **Usage:**
 
@@ -21,6 +27,7 @@ genogrove idx [OPTIONS] <inputfile>
 - `-o, --outputfile <file>`: Output index file (default: `<inputfile>.gg`, written next to the input)
 - `-k, --order <int>`: B+ tree order (default: 3, minimum: 3)
 - `-s, --sorted`: Assert the input intervals are coordinate-sorted (enables the faster sorted-append path)
+- `-l, --links <file>`: Attach directed graph edges from a name-keyed TSV (BED input only — see [Links](#links-attaching-graph-edges) below)
 - `-t, --timed`: Print the indexing time
 
 **Examples:**
@@ -34,16 +41,83 @@ genogrove idx target.bed -o /data/target.gg
 
 # Pre-sorted input, with timing
 genogrove idx -s -t sorted.bed
+
+# Index a GFF/GTF file
+genogrove idx annotation.gff3 -o annotation.gg
+
+# Attach graph edges from a links TSV (BED input only)
+genogrove idx features.bed -l links.tsv -o features.gg
 ```
 
 ```{note}
-Only BED input is currently supported (`.bed`, `.bed.gz`). GFF/GTF input is planned.
+The `.gg` header records a `payload_type` byte that distinguishes index types (`0x01` BED,
+`0x02` GFF). `isec` uses this byte to instantiate the correct grove type. See the
+serialization / file-format guide for the full header layout.
+```
+
+```{note}
+`idx` builds the grove fully in memory before opening the output file, so a parse error
+mid-insert (or a malformed links file) aborts before any existing `.gg` at the output path
+is touched — it can never leave a truncated index behind.
+```
+
+#### Links: attaching graph edges
+
+`idx -l/--links FILE` attaches directed edges to the grove's `graph_overlay` from a name-keyed
+TSV. The edges are part of grove serialization, so a later `isec -i` against the resulting `.gg`
+sees them with no extra work.
+
+**Links file format** — a 2-column TSV:
+
+- Comment lines (starting with `#`) and blank lines are skipped.
+- Each row `nameA<TAB>nameB` adds a directed edge `nameA → nameB`.
+- Names are matched against BED column 4 (the `name` field).
+- A row that is not exactly two non-empty tab-separated columns is an error naming the line number.
+
+**Constraints:**
+
+- BED input only — GFF/GTF links are a future follow-up.
+- Names must be unique within the BED file; a duplicate column-4 name aborts indexing.
+- Every linked name must resolve to a BED record; an unresolved name aborts, naming the missing name.
+- Repeated rows are de-duplicated, because `graph_overlay::add_edge` does not deduplicate (see the
+  graph edges guide).
+- Per-edge metadata is not yet supported (2-column TSV only).
+
+The grove and its edges are built fully in memory before the output `.gg` is opened, so a malformed
+links file or unresolved name aborts before any existing `.gg` at the output path is touched.
+
+**Example** — a BED6 with named features:
+
+```text
+chr1    100    200    geneA    0    +
+chr1    300    400    geneB    0    +
+chr1    500    600    geneC    0    +
+```
+
+and a links TSV (`links.tsv`):
+
+```text
+# regulatory edges
+geneA    geneB
+geneB    geneC
+```
+
+build an index whose graph edges are visible through the library's graph accessors and to `isec`:
+
+```bash
+genogrove idx features.bed -l links.tsv -o features.gg
+
+# The edges geneA → geneB and geneB → geneC travel with the .gg
+genogrove isec -q regions.bed -i features.gg
 ```
 
 ### isec (Intersect)
 
 Finds overlapping intervals between a query file and a target. The target can be built on the fly
-from a BED file (`-t`) or loaded from a prebuilt `.gg` index (`-i`).
+from a BED or GFF/GTF file (`-t`) or loaded from a prebuilt `.gg` index (`-i`).
+
+`isec` dispatches on type: with `-i <prebuilt.gg>` the `.gg` header's `payload_type` byte tells it
+which grove type to instantiate; with `-t <target>` the file-type detector picks the path.
 
 **Usage:**
 
@@ -62,6 +136,11 @@ genogrove isec -q <queryfile> (-t <targetfile> | -i <indexfile>) [OPTIONS]
 Either `-t` or `-i` must be supplied — at least one is required. When both are given, `-i` takes
 precedence and `-t` is ignored. `-k` only affects the grove built from `-t`; an index loaded via
 `-i` keeps the order it was created with.
+
+```{note}
+Cross-type queries (for example a BED query against a GFF index) are deliberately rejected in this
+release — the query, target, and index types must match.
+```
 
 **Examples:**
 
@@ -100,10 +179,18 @@ genogrove isec -q regions.bed -i genes.gg
 
 Currently supported:
 
-- BED format (`.bed`, `.bed.gz`) — for query and target input
+- BED format (`.bed`, `.bed.gz`) — for query and target input, and for `idx` links (`-l`)
+- GFF/GTF format (`.gff3`, `.gtf`, gzip-compressed variants) — for query and target input
 - `.gg` index files (produced by `idx`) — for the `isec -i` search target
+
+```{note}
+Query, target, and index types must match — cross-type intersection (e.g. a BED query against a
+GFF index) is not supported in this release. The `.gg` `payload_type` byte (`0x01` BED, `0x02` GFF)
+records which type an index holds.
+```
 
 Planned support:
 
-- GFF/GTF format
+- GFF/GTF links for `idx -l` (currently BED-only)
+- Per-edge link metadata
 - VCF format

--- a/source/guide/grove/graph.md
+++ b/source/guide/grove/graph.md
@@ -80,6 +80,35 @@ my_grove.add_edge(key1, key2, 0.95);
 - Keys from different indices (chromosomes) can be linked
 - The graph overlay shares the grove's lifetime
 
+#### Parallel Edges (No Deduplication)
+
+`add_edge(source, target)` appends to the source's adjacency list **unconditionally** — there is no
+deduplication. Calling it twice with the same `(source, target)` creates two **parallel** edges. This is
+intentional: parallel edges carrying distinct per-edge metadata are a legitimate use case.
+
+Observable effects of adding the same edge `a → b` twice:
+
+```cpp
+my_grove.add_edge(a, b);
+my_grove.add_edge(a, b);          // appends a second, parallel edge
+
+my_grove.out_degree(a);           // == 2 (counts every edge)
+my_grove.get_neighbors(a);        // == {b, b} (b appears twice)
+my_grove.has_edge(a, b);          // == true (existence only, unaffected by count)
+// get_edges(a) likewise reflects the duplicate (one metadata entry per edge)
+```
+
+Both edges are serialized into the `.gg` file.
+
+**Other edge rules:**
+
+- Self-edges are allowed: `add_edge(a, a)` is valid.
+- A null `source` or `target` throws `std::invalid_argument`.
+
+**Implication for callers:** if duplicate edges are undesirable, deduplicate **before** calling `add_edge`.
+For example, the CLI's `idx --links` applier tracks seen `(source, target)` pairs in a `std::set` and skips
+edges it has already added.
+
 #### Building Graphs with Bulk Insert
 
 When using bulk insert operations, you receive a vector of key pointers that can be directly used to create edges.
@@ -642,7 +671,10 @@ g.out_degree(a)            # 1
 - `vertex_count_with_edges() -> int` — keys with at least one outgoing edge.
 
 :::{note}
-`add_edge` does **not** deduplicate — calling it twice creates parallel edges.
+`add_edge` does **not** deduplicate — calling it twice with the same `(source, target)` appends a second,
+parallel edge. After a duplicate `a → b`: `out_degree(a) == 2`, `get_neighbors(a) == [b, b]`, but
+`has_edge(a, b)` stays `True` (existence only). Both edges are written to the `.gg`. Deduplicate before
+calling if duplicates are undesirable.
 :::
 
 ### External keys

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -121,6 +121,62 @@ int main() {
   splits with `order == 2` would produce a sibling with zero keys, which classical B+ trees forbid.
   The default constructor (`grove()`) uses order 3.
 
+### Dataless Groves (`data_type = void`)
+
+The `data_type` template parameter is **optional**. A grove parameterised with the key type
+alone — e.g. `gst::grove<gdt::interval>` — is a fully supported, first-class configuration that
+stores keys only, with no associated payload.
+
+On a dataless grove you insert pre-built `gdt::key<key_type>` objects through the public
+`insert(index, key)` method, and add graph-only nodes through the single-argument
+`add_external_key(key_value)` overload:
+
+```cpp
+#include <genogrove/structure/grove/grove.hpp>
+#include <genogrove/data_type/interval.hpp>
+#include <genogrove/data_type/key.hpp>
+
+namespace gdt = genogrove::data_type;
+namespace gst = genogrove::structure;
+
+int main() {
+    // No data_type argument — defaults to void (keys only)
+    gst::grove<gdt::interval> my_grove(100);
+
+    // Insert via insert(index, key) with a dataless key, constructed from a
+    // value only — there is no data argument.
+    gdt::key<gdt::interval> k{gdt::interval{100, 200}};
+    auto* inserted = my_grove.insert("chr1", k);   // returns key<interval>*
+
+    // Overlap queries work exactly as on a data-carrying grove
+    auto results = my_grove.intersect(gdt::interval{150, 175}, "chr1");
+
+    // Add a graph-only node with the single-argument add_external_key overload
+    auto* enhancer = my_grove.add_external_key(gdt::interval{5000, 5500});
+    my_grove.add_edge(inserted, enhancer);
+
+    return 0;
+}
+```
+
+The data-carrying public API is intentionally **unavailable** when `data_type = void` — these
+members are guarded by `requires (!std::is_void_v<data_type>)` and will not compile on a dataless
+grove:
+
+- the `insert_data(...)` family, including the variants that take the `gst::sorted` and `gst::bulk`
+  tags
+- the two-argument `add_external_key(key_value, data_value)` overload
+
+Conversely, the single-argument `add_external_key(key_value)` overload is available **only** when
+`data_type = void`. Match the insertion API to the grove's configuration: `insert_data` /
+two-argument `add_external_key` for data-carrying groves, `insert` / single-argument
+`add_external_key` for dataless ones.
+
+:::{note}
+This dataless `data_type = void` configuration is the one the Python bindings (`pygenogrove`)
+are built on.
+:::
+
 ### Ownership Semantics
 
 `grove` (and its internal `node` type) is **non-copyable and move-only**. Copy construction and

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -683,6 +683,148 @@ for (const auto& entry : gff_reader) {
   directory).
 - `fasta_index` is non-copyable and movable.
 
+### VCF/BCF Files
+
+VCF and BCF files store genomic variant calls. The `vcf_reader` is a
+`file_reader<vcf_entry>` that iterates VCF/BCF records — plain text, bgzipped, and binary BCF are
+all auto-detected by htslib. It follows the same single-pass iterator and error contract as the
+other readers: iterate with a range-for and check `get_error_message()` after the loop.
+
+Coordinates are stored in **0-based half-open** `[start, end)` form: `start = POS - 1` and
+`end = start + len(REF)`. Convert to a closed grove key with `gdt::interval(start, end - 1)` —
+this matches BED/BAM, **not** GFF.
+
+```cpp
+#include <genogrove/io/vcf_reader.hpp>
+#include <iostream>
+
+namespace gio = genogrove::io;
+
+int main() {
+    // Plain VCF, bgzipped VCF, and binary BCF are auto-detected.
+    gio::vcf_reader reader("calls.vcf");
+
+    for (const auto& entry : reader) {
+        std::cout << entry.chrom << ":" << entry.start << "-" << entry.end
+                  << "  REF=" << entry.ref << "\n";
+
+        if (!entry.qual_missing) {
+            std::cout << "  QUAL: " << entry.qual << "\n";
+        }
+
+        if (entry.is_snp()) {
+            std::cout << "  SNP\n";
+        } else if (entry.is_indel()) {
+            std::cout << "  indel\n";
+        }
+
+        // Per-sample genotypes (parallel to reader.get_sample_names()).
+        for (const auto& sample : entry.samples) {
+            std::cout << "  GT: " << sample.gt_string() << "\n";
+        }
+    }
+
+    // Lenient/skip-filtered records do not throw — check the error message after the loop.
+    if (!reader.get_error_message().empty()) {
+        std::cerr << "Last record error: " << reader.get_error_message() << "\n";
+    }
+
+    return 0;
+}
+```
+
+#### Reader Options
+
+`vcf_reader_options` uses C++20 designated initializers, like the other reader options:
+
+```cpp
+namespace gio = genogrove::io;
+
+// Factory presets
+gio::vcf_reader r1("calls.vcf", gio::vcf_reader_options::defaults());     // parse everything
+gio::vcf_reader r2("calls.vcf", gio::vcf_reader_options::sites_only());   // skip per-sample data
+
+// Custom options (designated initializers)
+gio::vcf_reader r3("calls.vcf",
+    gio::vcf_reader_options{.parse_samples = false, .skip_filtered = true});
+```
+
+- `parse_info` (bool, default `true`): Populate the typed `info` map.
+- `parse_samples` (bool, default `true`): Decode the per-sample `samples` vector.
+- `skip_filtered` (bool, default `false`): Skip records that did not pass FILTER.
+
+`vcf_reader` is **non-copyable** but **movable**, like the other readers.
+
+#### Reader Accessors
+
+Inspect the header and sample/contig metadata before or after iteration:
+
+- `get_header()` — returns the raw VCF header text (`const std::string&`)
+- `get_sample_names()` — returns the sample names (`const std::vector<std::string>&`); each
+  `vcf_entry::samples` element is parallel to this vector
+- `get_contigs()` — returns the contig names declared in the header (`const std::vector<std::string>&`)
+- `get_current_line()` — 1-based index of the most recently consumed record (`size_t`). Counts
+  records dropped by `skip_filtered`, and returns `0` before the first read.
+
+#### VCF Entry Fields
+
+- `chrom` (std::string): Contig/chromosome name
+- `start` (size_t): Start position (0-based, `POS - 1`)
+- `end` (size_t): End position (0-based half-open, `start + len(REF)`)
+- `id` (std::string): Variant ID (empty when `.`)
+- `ref` (std::string): Reference allele
+- `alt` (std::vector\<std::string>): Alternate alleles — empty for monomorphic `ALT=.`; symbolic
+  alleles (`<*>`, `<NON_REF>`, `*`) are kept verbatim
+- `qual` (float): Variant quality
+- `qual_missing` (bool): `true` when QUAL is `.` (then `qual` is unset)
+- `filter` (std::vector\<std::string>): FILTER values — `["PASS"]` when passed, empty when `.`
+- `info` (vcf_info): Typed INFO map (populated when `parse_info` is enabled)
+- `format` (std::vector\<std::string>): FORMAT keys, in column order
+- `samples` (std::vector\<sample_genotype>): Per-sample data, parallel to `get_sample_names()`
+
+#### Predicates
+
+- `passed_filter()` — `true` if the record passed FILTER
+- `is_snp()` — single-base REF/ALT substitution
+- `is_indel()` — insertion or deletion
+- `is_symbolic_allele(allele)` — static; `true` for symbolic alleles (`<*>`, `<NON_REF>`, `*`)
+
+Symbolic alleles are retained verbatim in `alt` but are **excluded** from the `is_snp()` /
+`is_indel()` predicates. Monomorphic records (`ALT=.`) yield an empty `alt`.
+
+#### Sample Genotypes
+
+Each `sample_genotype` in `entry.samples` decodes one sample's FORMAT data:
+
+- `gt_alleles` (std::vector\<int32_t>): Allele indices (`0` = REF, `1..` = ALT index, `-1` = missing)
+- `phased` (bool): `true` for phased genotypes (`|` separator)
+- `has_gt` (bool): `true` if a GT field was present
+- `fields` (std::unordered_map\<std::string, vcf_format_value>): Other FORMAT fields (everything
+  except GT)
+- `gt_string()` — renders the genotype, e.g. `"0/1"`, `"0|1"`, `"./."`
+- `is_hom_ref()` — `true` if homozygous reference
+
+Ragged numeric FORMAT fields are trimmed of htslib's `*_vector_end` padding.
+
+#### Value Types
+
+INFO and FORMAT values are stored as `std::variant`s:
+
+- `vcf_info_value` = `std::variant<...>` over the htslib INFO types: Flag (`bool`), Int, Float,
+  and String.
+- `vcf_format_value` = `std::variant<...>` over the FORMAT types: Int, Float, and String.
+- `vcf_info` = `std::unordered_map<std::string, vcf_info_value>` (the type of `vcf_entry::info`).
+
+```cpp
+// Read a typed INFO value
+auto it = entry.info.find("DP");
+if (it != entry.info.end()) {
+    if (auto* dp = std::get_if<int>(&it->second)) {
+        std::cout << "Depth: " << *dp << "\n";
+    }
+}
+```
+
 ::::
 
 ::::{tab-item} Python

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -234,6 +234,91 @@ auto g = gst::grove<...>::deserialize(buf);
 - **Breaking format change**: The serialized format now includes graph edges after external keys. Files serialized with older versions are incompatible and must be re-created.
 - All `deserialize` methods are marked `[[nodiscard]]` to prevent accidentally discarding the result.
 
+### The `.gg` File Header
+
+Every `.gg` file produced by the `idx` CLI subcommand begins with a **12-byte plain (uncompressed)
+header** written before the zlib-compressed grove payload. Because it is uncompressed, a `.gg` file
+can be identified and validated without decompressing first (e.g. with `xxd` or `file`). The
+`intersect -i` (`isec`) subcommand validates this header before deserializing.
+
+The on-disk layout is:
+
+| Offset | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 4 | `magic` = `"GROV"` | inspectable via `xxd` / `file` |
+| 4 | 1 | `format_major` = 0 | pre-1.0; any change may break compatibility |
+| 5 | 1 | `format_minor` = 1 | starts at 0.1 |
+| 6 | 1 | `lib_major` | informational |
+| 7 | 1 | `lib_minor` | informational |
+| 8 | 1 | `lib_patch` | informational |
+| 9 | 1 | `payload_type` | `0x01` = BED, `0x02` = GFF |
+| 10 | 2 | `reserved` | zero |
+
+The API lives in `genogrove::io`:
+
+```cpp
+#include <genogrove/io/gg_format.hpp>
+
+namespace gio = genogrove::io;
+
+enum class gg_payload_type : uint8_t { BED = 0x01, GFF = 0x02 };
+
+struct gg_header {
+    [[nodiscard]] static gg_header current(gg_payload_type payload_type);  // writer-side factory
+    void write(std::ostream& os) const;                                    // write the 12 bytes
+    [[nodiscard]] static gg_header read(std::istream& is);                 // read + validate
+};
+```
+
+- `gg_header::current(payload_type)` builds a header stamped with the current library version and
+  the given payload type — use it on the writer side.
+- `write(std::ostream&)` writes the 12-byte header.
+- `gg_header::read(std::istream&)` reads and validates the header. It throws `std::runtime_error`
+  on a bad magic value, an unsupported `(format_major, format_minor)` pair, or an unknown
+  `payload_type`. Library-version differences (`lib_major`/`lib_minor`/`lib_patch`) are
+  **informational only** and never cause rejection.
+
+:::{warning}
+**No backwards compatibility.** Pre-existing `.gg` files written before this header was added no
+longer parse and must be re-indexed. This is consistent with the project's
+no-backwards-compatibility-for-serialization policy.
+:::
+
+### SIF Export (visualization)
+
+The grove can be exported to **SIF** (Simple Interaction Format) text for visualization in tools
+such as Cytoscape. Two overloads are available:
+
+```cpp
+// Whole-grove export: walks the grove's own roots, no node pointer needed.
+void grove_to_sif(std::ostream& os) const;
+
+// Per-tree primitive: visualize a single tree given its root node.
+void grove_to_sif(std::ostream& os, const node<key_type, data_type>* root) const;
+```
+
+The node-less overload exports the **entire grove** (all indexed trees) in one call. An empty grove
+produces no output. Both overloads are stream-only by design (mirroring `serialize()` /
+`deserialize()`) — there is intentionally **no** `to_sif(path)` overload, so callers wrap their own
+`std::ofstream`:
+
+```cpp
+#include <fstream>
+
+std::ofstream out("grove.sif");
+my_grove.grove_to_sif(out);   // writes every indexed tree
+```
+
+The per-tree overload (`grove_to_sif(os, root)`) remains available for visualizing a single tree.
+
+The output is tab-separated and uses three interaction types: `nodelink` (internal node → child),
+`leaflink` (leaf → next leaf), and `keylink` (key → graph-overlay neighbour).
+
+:::{warning}
+Index iteration order is **not stable across runs** (hash-map iteration) — treat the output as a
+*set* of interactions rather than an ordered list.
+:::
+
 ::::
 
 ::::{tab-item} Python

--- a/source/reference/cpp/io.md
+++ b/source/reference/cpp/io.md
@@ -52,6 +52,14 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
+### vcf_reader
+
+```{eval-rst}
+.. doxygenclass:: genogrove::io::vcf_reader
+   :members:
+   :undoc-members:
+```
+
 
 ## Entry Types
 
@@ -87,6 +95,22 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
+### vcf_entry
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::vcf_entry
+   :members:
+   :undoc-members:
+```
+
+### sample_genotype
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::sample_genotype
+   :members:
+   :undoc-members:
+```
+
 ## Reader Options
 
 ### bed_reader_options
@@ -117,6 +141,14 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
 
 ```{eval-rst}
 .. doxygenstruct:: genogrove::io::fasta_reader_options
+   :members:
+   :undoc-members:
+```
+
+### vcf_reader_options
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::vcf_reader_options
    :members:
    :undoc-members:
 ```
@@ -189,6 +221,30 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
    :undoc-members:
 ```
 
+## VCF Support Types
+
+### vcf_info_value
+
+```{eval-rst}
+.. doxygentypedef:: genogrove::io::vcf_info_value
+```
+
+### vcf_format_value
+
+```{eval-rst}
+.. doxygentypedef:: genogrove::io::vcf_format_value
+```
+
+## .gg Format Types
+
+### gg_header
+
+```{eval-rst}
+.. doxygenstruct:: genogrove::io::gg_header
+   :members:
+   :undoc-members:
+```
+
 ## Enums
 
 ### filetype
@@ -213,4 +269,10 @@ The `genogrove::io` namespace contains file readers and parsers for genomic file
 
 ```{eval-rst}
 .. doxygenenum:: genogrove::io::cigar_op
+```
+
+### gg_payload_type
+
+```{eval-rst}
+.. doxygenenum:: genogrove::io::gg_payload_type
 ```


### PR DESCRIPTION
## What & why

Documents the public API surface added in genogrove v0.24.7 (and the GFF/`--links`/`.gg`-header work from genogrove#424). One batched PR per the docs workflow.

## Changes

- **`guide/io.md`** — C++ `vcf_reader` / `vcf_entry` / `sample_genotype` / `vcf_reader_options` + `vcf_info_value`/`vcf_format_value`, with the 0-based half-open coordinate callout (`gdt::interval(start, end - 1)`, matches BED/BAM not GFF). Python `VcfReader` already existed, so C++ side only. (closes #161)
- **`reference/cpp/io.md`** — autodoc stubs for the VCF types, plus `gg_header` and `gg_payload_type`. (supports #161, #142)
- **`guide/serialization.md`** — the 12-byte `.gg` file header layout + `gg_header` API and re-index note (closes #142); node-less `grove_to_sif(std::ostream&)` whole-grove SIF export (closes #162).
- **`cli.md`** — `idx`/`isec` GFF/GTF dispatch and `.gg` `payload_type` byte, the cross-type-query restriction (closes #143); `idx -l/--links` TSV format + constraints + worked example (closes #145).
- **`guide/grove/grove.md`** — dataless `grove<key_type>` (`data_type = void`) as a first-class config. (closes #146)
- **`guide/grove/graph.md`** — `add_edge` does not deduplicate: parallel edges, self-edges, null-endpoint throws. (closes #144)

## Notes

- Version string bump to 0.24.7 (#163) is handled separately (version-string-only).
- All signatures verified against the `repos/genogrove` clone (at `1af9e79`).
- Please run `make clean && make html` to confirm zero Sphinx/Doxygen warnings before merge.

closes #161
closes #162
closes #142
closes #143
closes #144
closes #145
closes #146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI docs for `genogrove idx` and `genogrove isec`, including automatic input-type detection, clearer type-matching rules, and a new links option with examples and parsing guidance.
  * Added guidance for graph edge behavior, dataless groves, and VCF/BCF handling, including reader options, coordinates, genotype fields, and typed value access.
  * Documented `.gg` file header details, compatibility warnings, and SIF export behavior for visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->