### PR TITLE
Pin Read the Docs to Python 3.12 (pygenogrove wheel availability)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,10 @@ version: 2
 # Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04
+  # 3.12, not 3.13: pygenogrove ships cp39–cp312 wheels only. On 3.13 pip falls
+  # back to the sdist and compiles from source (needs htslib), which fails here.
   tools:
-    python: "3.13"
+    python: "3.12"
   apt_packages:
     - doxygen
   jobs:


### PR DESCRIPTION
## Problem

The RTD build (commit da862c7) failed at the pip-install step: `pygenogrove==0.5.0` has no cp313 wheel, so on RTD's pinned Python 3.13 pip fell back to the sdist and tried to **compile from source**, which needs htslib (not present in the build env) — CMake aborted with `Package 'htslib' not found`.

This would fail for **any** pin (all versions ship cp39–cp312 wheels only), not just 0.5.0.

## Fix

Point RTD at Python **3.12**, which has a prebuilt `manylinux` wheel for pygenogrove — no source build, no htslib needed. Keeps the pip-pinned-wheel strategy intact.

## Follow-up

Revert to 3.13 once pygenogrove publishes cp313 wheels upstream.