### PR TITLE
Bump pygenogrove to 0.6.0 (align autodoc with documented surface)

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -16,7 +16,7 @@ release = "0.24.7"
 # pygenogrove (Python bindings) versions independently of the C++ library and
 # currently lags it; the Python guide tabs reflect this surface. Bump alongside
 # the pin in source/requirements.txt.
-pygenogrove_release = "0.5.0"
+pygenogrove_release = "0.6.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -9,4 +9,4 @@ sphinx-design>=0.5.0
 # If it cannot be installed/imported, conf.py skips that section gracefully.
 # Pinned to the surface the reference docs were written against (avoids autodoc
 # drifting to a newer PyPI release than the documented API).
-pygenogrove==0.5.0
+pygenogrove==0.6.0


### PR DESCRIPTION
## Why

The Python guide tabs and `reference/python/*` already document the **pygenogrove 0.6.0** surface — `Numeric`/`Kmer` + `NumericGrove`/`KmerGrove`, `VcfReader`/`VcfEntry`, `to_sif`, and the `StringRegistry → Registry` rename. But the autodoc pin lagged at `0.5.0`, so the generated Python reference was built from a version missing those classes.

## Change

- `source/requirements.txt`: `pygenogrove==0.5.0` → `==0.6.0`
- `source/conf.py`: `pygenogrove_release` → `0.6.0` (drives the Python tab label)

0.6.0 ships a `cp312` manylinux wheel, so the RTD build (Python 3.12) stays wheel-only — no source compile.

## Verify in build

- The Python reference now renders `Numeric`/`Kmer`/`NumericGrove`/`KmerGrove`/`VcfReader`/`Registry` (previously importable-missing on 0.5.0).
- No new autodoc warnings — the `VcfEntry.is_symbolic_allele` exclusion is already in `reference/python/io.md`.
- Python tab labels read **Python · pygenogrove 0.6.0**.

Note: 0.6.0 is a breaking pygenogrove release (`StringRegistry → Registry`), already reflected in the docs (`registry.md` documents `Registry` with a rename note).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the displayed Python bindings version in the docs from 0.5.0 to 0.6.0.
  * Kept version labels and tabs in sync with the latest release.
* **Chores**
  * Bumped the pinned documentation build dependency to the newer 0.6.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->