### PR TITLE
Drop C++ release from navbar title

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -127,6 +127,10 @@ autodoc_default_options = {
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+# Drop the default "<project> <release> documentation" title so the navbar
+# doesn't brand the whole site with the C++ `release` — genogrove and
+# pygenogrove version independently and each guide tab is stamped with its own.
+html_title = "genogrove"
 
 html_theme_options = {
     "github_url": "https://github.com/genogrove/genogrove",


### PR DESCRIPTION
The navbar title defaulted to `genogrove 0.24.7 documentation`, branding the whole site with the C++ `release`. genogrove and pygenogrove version independently and each guide tab is already stamped with its own version, so the global one is redundant and misleading.

Sets `html_title = "genogrove"` → navbar reads just "genogrove".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation site title to display “genogrove” consistently.
  * Added clearer guidance around how the different guide versions are handled and labeled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->