### PR TITLE
Document v0.25 CLI + serialization changes

### DIFF
--- a/source/cli.md
+++ b/source/cli.md
@@ -27,7 +27,8 @@ genogrove idx [OPTIONS] <inputfile>
 - `-o, --outputfile <file>`: Output index file (default: `<inputfile>.gg`, written next to the input)
 - `-k, --order <int>`: B+ tree order (default: 3, minimum: 3)
 - `-s, --sorted`: Assert the input intervals are coordinate-sorted (enables the faster sorted-append path)
-- `-l, --links <file>`: Attach directed graph edges from a name-keyed TSV (BED input only — see [Links](#links-attaching-graph-edges) below)
+- `-l, --links <file>`: Attach directed graph edges from a name-keyed TSV (BED or GFF/GTF input — see [Links](#links-attaching-graph-edges) below)
+- `--gff-name-tag <attr>`: For GFF/GTF input with `--links`, the attribute whose value identifies each record for link matching (e.g. `ID`, `gene_id`, `transcript_id`). Required for `--links` on GFF/GTF; ignored for BED input
 - `-t, --timed`: Print the indexing time
 
 **Examples:**
@@ -45,8 +46,11 @@ genogrove idx -s -t sorted.bed
 # Index a GFF/GTF file
 genogrove idx annotation.gff3 -o annotation.gg
 
-# Attach graph edges from a links TSV (BED input only)
+# Attach graph edges from a links TSV (BED input)
 genogrove idx features.bed -l links.tsv -o features.gg
+
+# Attach graph edges to a GFF/GTF index, matching on the ID attribute
+genogrove idx genes.gff3 -l links.tsv --gff-name-tag ID -o genes.gg
 ```
 
 ```{note}
@@ -61,27 +65,36 @@ mid-insert (or a malformed links file) aborts before any existing `.gg` at the o
 is touched — it can never leave a truncated index behind.
 ```
 
+(cli-links)=
 #### Links: attaching graph edges
 
 `idx -l/--links FILE` attaches directed edges to the grove's `graph_overlay` from a name-keyed
 TSV. The edges are part of grove serialization, so a later `isec -i` against the resulting `.gg`
 sees them with no extra work.
 
-**Links file format** — a 2-column TSV:
+**Links file format** — a 2- or 3-column TSV:
 
 - Comment lines (starting with `#`) and blank lines are skipped.
 - Each row `nameA<TAB>nameB` adds a directed edge `nameA → nameB`.
-- Names are matched against BED column 4 (the `name` field).
-- A row that is not exactly two non-empty tab-separated columns is an error naming the line number.
+- An optional 3rd tab-separated field attaches per-edge metadata to that edge — a raw string
+  (`nameA<TAB>nameB<TAB>supports_isoform=ENST00001`), stored verbatim with no quoting or escaping.
+- Names are matched against BED column 4 (the `name` field), or — for GFF/GTF input — against the
+  attribute named by `--gff-name-tag` (see below).
+- A row that is not exactly 2 or 3 tab-separated columns, or that has any empty column (including a
+  present-but-empty 3rd), is an error naming the line number.
 
 **Constraints:**
 
-- BED input only — GFF/GTF links are a future follow-up.
-- Names must be unique within the BED file; a duplicate column-4 name aborts indexing.
-- Every linked name must resolve to a BED record; an unresolved name aborts, naming the missing name.
-- Repeated rows are de-duplicated, because `graph_overlay::add_edge` does not deduplicate (see the
-  graph edges guide).
-- Per-edge metadata is not yet supported (2-column TSV only).
+- BED and GFF/GTF input are supported. On GFF/GTF, `--links` **requires** `--gff-name-tag <attr>`
+  — there is no canonical name column, so the identifying attribute must be named explicitly.
+  Omitting it aborts indexing.
+- Names must be unique within the file; a duplicate BED column-4 name (or a duplicate
+  `--gff-name-tag` attribute value) aborts indexing. On GFF/GTF, every record must carry the chosen
+  attribute — a missing attribute aborts, naming the record.
+- Every linked name must resolve to a record; an unresolved name aborts, naming the missing name.
+- Exact-duplicate rows are de-duplicated (`graph_overlay::add_edge` does not deduplicate — see the
+  graph edges guide). The dedup key includes the metadata, so the same `(source, target)` pair with
+  two *different* metadata values yields two parallel edges.
 
 The grove and its edges are built fully in memory before the output `.gg` is opened, so a malformed
 links file or unresolved name aborts before any existing `.gg` at the output path is touched.
@@ -111,6 +124,20 @@ genogrove idx features.bed -l links.tsv -o features.gg
 genogrove isec -q regions.bed -i features.gg
 ```
 
+**GFF/GTF input** — because GFF/GTF has no name column, name `--gff-name-tag` to select the
+identifying attribute. The values of that attribute must be present on every record and unique
+across the file:
+
+```bash
+# Match links against the GFF3 ID attribute
+genogrove idx genes.gff3 -l links.tsv --gff-name-tag ID -o genes.gg
+
+# Match against a GTF gene_id
+genogrove idx genes.gtf -l links.tsv --gff-name-tag gene_id -o genes.gg
+```
+
+On BED input `--gff-name-tag` is ignored (BED links always match column 4) — it is not an error.
+
 ### isec (Intersect)
 
 Finds overlapping intervals between a query file and a target. The target can be built on the fly
@@ -127,9 +154,10 @@ genogrove isec -q <queryfile> (-t <targetfile> | -i <indexfile>) [OPTIONS]
 
 **Options:**
 
-- `-q, --queryfile <file>`: Query BED file (required)
-- `-t, --targetfile <file>`: Target BED file to build the grove from (one of `-t` / `-i` required)
+- `-q, --queryfile <file>`: Query BED or GFF/GTF file (required)
+- `-t, --targetfile <file>`: Target BED or GFF/GTF file to build the grove from (one of `-t` / `-i` required)
 - `-i, --indexfile <file>`: Prebuilt `.gg` index to search against (one of `-t` / `-i` required)
+- `--in-place`: Query the prebuilt index (`-i`) on disk, reading only the blocks each query touches instead of loading the whole file into memory (requires `-i`)
 - `-o, --outputfile <file>`: Output destination (default: stdout)
 - `-k, --order <int>`: B+ tree order used when building from `-t` (default: 3, minimum: 3)
 
@@ -137,9 +165,47 @@ Either `-t` or `-i` must be supplied — at least one is required. When both are
 precedence and `-t` is ignored. `-k` only affects the grove built from `-t`; an index loaded via
 `-i` keeps the order it was created with.
 
-```{note}
-Cross-type queries (for example a BED query against a GFF index) are deliberately rejected in this
-release — the query, target, and index types must match.
+#### Cross-type queries
+
+The query file type and the target/index type are **independent** — all four BED/GFF combinations
+work. The query type only selects how query records are iterated; the output format follows the
+**target/index** payload type (a `.gg` index holds one payload type):
+
+| Query | Target / Index | Output |
+|---|---|---|
+| BED | BED | BED rows |
+| BED | GFF | GFF rows |
+| GFF | BED | BED rows |
+| GFF | GFF | GFF rows |
+
+To make cross-type overlaps correct, both readers map to a common **0-based-inclusive** interval
+space internally: BED `[start, end)` → `interval(start, end-1)`; GFF/GTF `[start, end]` (1-based) →
+`interval(start-1, end-1)`. The printed output coordinates are unchanged — each hit is emitted with
+the raw entry coordinates of the target payload.
+
+```{warning}
+The internal GFF interval numbering shifted by −1 to share this space, so the `.gg` on-disk format
+changed for GFF payloads. **GFF indexes built before v0.25.0 must be regenerated** (`genogrove idx`).
+See the {doc}`serialization guide </guide/serialization>` — there is no serialization back-compat.
+```
+
+(in-place-querying)=
+#### In-place querying
+
+By default `isec -i` deserializes the whole `.gg` into memory. `--in-place` instead queries the
+index on disk via a partial reader ([`grove_view`](#partial-reading-with-grove-view)),
+loading only the blocks each query walks. Output is identical to the eager path — it is a
+memory/latency trade-off:
+
+- `--in-place` **requires `-i`**. Using it with a `-t` target (built in memory, no on-disk index)
+  errors: `--in-place requires a prebuilt index (-i)`.
+- It wins for targeted queries and is the only option when the index is larger than RAM. For a
+  dense whole-genome query file the (non-evicting) block cache ends up loading most blocks anyway,
+  so it is roughly at parity with the eager path there.
+
+```bash
+genogrove isec -q query.bed -i index.gg              # eager (default)
+genogrove isec -q query.bed -i index.gg --in-place   # partial read
 ```
 
 **Examples:**
@@ -180,17 +246,16 @@ genogrove isec -q regions.bed -i genes.gg
 Currently supported:
 
 - BED format (`.bed`, `.bed.gz`) — for query and target input, and for `idx` links (`-l`)
-- GFF/GTF format (`.gff3`, `.gtf`, gzip-compressed variants) — for query and target input
+- GFF/GTF format (`.gff3`, `.gtf`, gzip-compressed variants) — for query and target input, and for
+  `idx` links (`-l` with `--gff-name-tag`)
 - `.gg` index files (produced by `idx`) — for the `isec -i` search target
 
 ```{note}
-Query, target, and index types must match — cross-type intersection (e.g. a BED query against a
-GFF index) is not supported in this release. The `.gg` `payload_type` byte (`0x01` BED, `0x02` GFF)
-records which type an index holds.
+The query type and the target/index type are independent — a BED query may run against a GFF index
+and vice versa (see [Cross-type queries](#cross-type-queries)). The `.gg` `payload_type` byte
+(`0x01` BED, `0x02` GFF) records which payload an index holds, and the output follows it.
 ```
 
 Planned support:
 
-- GFF/GTF links for `idx -l` (currently BED-only)
-- Per-edge link metadata
 - VCF format

--- a/source/cli.md
+++ b/source/cli.md
@@ -65,7 +65,6 @@ mid-insert (or a malformed links file) aborts before any existing `.gg` at the o
 is touched — it can never leave a truncated index behind.
 ```
 
-(cli-links)=
 #### Links: attaching graph edges
 
 `idx -l/--links FILE` attaches directed edges to the grove's `graph_overlay` from a name-keyed
@@ -189,11 +188,10 @@ changed for GFF payloads. **GFF indexes built before v0.25.0 must be regenerated
 See the {doc}`serialization guide </guide/serialization>` — there is no serialization back-compat.
 ```
 
-(in-place-querying)=
 #### In-place querying
 
 By default `isec -i` deserializes the whole `.gg` into memory. `--in-place` instead queries the
-index on disk via a partial reader ([`grove_view`](#partial-reading-with-grove-view)),
+index on disk via a partial reader ([`grove_view`](guide/serialization.md#partial-random-access-reading)),
 loading only the blocks each query walks. Output is identical to the eager path — it is a
 memory/latency trade-off:
 

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -58,7 +58,28 @@ void persist(const gst::grove<gdt::interval, std::string>& g, std::ostream& os) 
 
 The grove serializes its complete B+ tree structure using **zlib compression**. The output is a
 compressed binary stream (not raw bytes), so files are compact but not directly inspectable with
-hex editors. Internally the data is written in a depth-first traversal:
+hex editors. The stream opens with a small plain directory (order, index count, per-index name +
+root block id, block counts), then the payload.
+
+**Block-structured payload (format 0.2).** As of genogrove v0.25.0 the payload is
+**block-structured**: each B+ tree node is an independently zlib-compressed, length-prefixed block,
+and external keys are distributed into fixed-size blocks. (Previously the whole file was a single
+zlib stream — format 0.1.) The block structure is what makes random-access partial reading possible
+— see [Partial reading with `grove_view`](#partial-reading-with-grove-view) below. Because each
+block is inflated from an isolated buffer of exactly its length, the source is read sequentially,
+so `grove::deserialize` now works on **non-seekable input streams** (pipes, sockets) and leaves any
+trailing bytes after the grove intact.
+
+The public signatures (`serialize(std::ostream&)` / `deserialize(std::istream&)`) are unchanged.
+
+```{warning}
+**No serialization back-compat.** Format 0.1 `.gg` files are **not readable** by a v0.25.0+ build
+and must be regenerated (re-run `genogrove idx` or re-`serialize()`). The header reports
+`format_major = 0`, `format_minor = 2`; while `format_major == 0` the format is still evolving and
+may break again. See [The `.gg` File Header](#the-gg-file-header).
+```
+
+Within a block the data is still written in depth-first order:
 
 1. Tree order and number of indices (chromosomes)
 2. For each index: the index name followed by the full tree (nodes, keys, and associated data)
@@ -199,31 +220,76 @@ struct genogrove::data_type::serialization_traits<ThirdPartyType> {
   files produced by the `idx` CLI subcommand are this form. `gio::rgb_color` and `gio::thick_info`
   are trivially copyable and serialize automatically.
 
-### Source Stream Must Be Seekable for Concatenated Payloads
+### Non-Seekable Sources and Concatenated Payloads
 
-`grove::deserialize()` uses zlib's streaming decoder, which may finish consuming the compressed
-payload before exhausting the input buffer. To preserve any bytes that follow the grove (e.g.,
-concatenated payloads, sentinel markers, file tails), the internal `inflate_streambuf` rewinds
-the unconsumed bytes via `source.seekg(...)`.
+As of format 0.2, `grove::deserialize()` reads each block from an isolated buffer of exactly its
+length, consuming the source **sequentially**. It no longer needs to rewind, so it works on
+**non-seekable sources** (pipes, sockets, custom streambufs) and leaves any bytes that follow the
+grove intact — the concatenated-payload pattern (registry then grove from the same stream, multiple
+grove payloads back-to-back, sentinel trailers) works without a seekable source.
 
-**The source stream must therefore be seekable when anything follows the grove in the stream.**
-On non-seekable sources (pipes, sockets, custom non-seekable streambufs) the seek fails and
-`deserialize()` throws:
+```{note}
+Random-access *partial* reading via [`grove_view`](#partial-reading-with-grove-view) still needs a
+seekable source — it seeks to individual block offsets — which is why `grove_view::open` takes a
+file path rather than an arbitrary stream. Eager `grove::deserialize` has no such requirement.
+```
 
-> `inflate_streambuf: source stream is not seekable; concatenated payloads require a seekable source`
+(partial-reading-with-grove-view)=
+### Partial reading with `grove_view`
 
-For a single-payload `.gg` file loaded via `std::ifstream`, this requirement is automatically
-satisfied — file streams are seekable. The requirement matters only for the concatenated-payload
-pattern (registry then grove from the same stream, multiple grove payloads back-to-back, sentinel
-trailers).
-
-If you must deserialize from a non-seekable source, copy it into a `std::stringstream` first:
+`genogrove::structure::grove_view` is a **read-only, partial reader** over a serialized format 0.2
+`.gg`. Where `grove::deserialize` eagerly loads the whole file, `grove_view` loads only the blocks a
+query walks and caches them for its lifetime. It complements — does not replace — the eager `grove`,
+which remains the builder and the load-it-all reader.
 
 ```cpp
-std::stringstream buf;
-buf << non_seekable_source.rdbuf();        // drain into a seekable buffer
-auto g = gst::grove<...>::deserialize(buf);
+#include <genogrove/structure/grove/grove_view.hpp>
+
+namespace gst = genogrove::structure;
+
+// Open a .gg for partial reading (seekable source required — takes a path).
+auto view = gst::grove_view<gdt::interval, gio::bed_entry, std::string>::open("index.gg");
+
+// Same intersect() signatures/semantics as grove — loads only the O(log n)
+// descent path plus overlapping leaves.
+auto hits = view.intersect(gdt::interval{100, 200}, "chr1");
+
+// Outgoing graph neighbours; loads only the edge-target block, across chromosomes.
+for (auto* k : hits.get_keys()) {
+    for (auto* nbr : view.get_neighbors(k)) { /* ... */ }
+}
 ```
+
+**Public surface** (`grove_view<key_type, data_type = void, edge_data_type = void>`):
+
+- `static grove_view open(const std::string& path, std::streamoff data_offset = 0)` — opens a `.gg`,
+  reads the directory, and scans the block chain to build a `block_id → file offset` index. Pass
+  `data_offset` to start past a leading wrapper (the CLI passes `gg_header::SIZE` to skip the 12-byte
+  header). Throws `std::runtime_error` on a missing file, bad magic, a non-seekable/truncated stream,
+  or a malformed directory.
+- `intersect(const key_type& query, std::string_view index)` and `intersect(const key_type& query)`
+  — same signatures and semantics as `grove::intersect` (they share the query engine).
+- `get_neighbors(const key* source)` — outgoing graph neighbours, loading only the target block
+  (including across chromosomes). `source` must be a key pointer this `grove_view` produced.
+- `blocks_loaded()` / `block_count()` — introspection (e.g. to assert a query really was partial).
+
+**Semantics worth calling out:**
+
+- **Non-copyable and non-movable** — it owns the file and a zlib state. Hold it by value from
+  `open()`; the return is guaranteed copy elision, so no move is needed.
+- **The block cache never evicts** — memory grows with the set of blocks touched, bounded by the
+  query footprint.
+- **Not thread-safe**, and no `flanking()` yet (eager `grove` only).
+- Requires a plain format-0.2 `.gg` written by `grove::serialize`.
+
+The CLI's `isec --in-place` is built on `grove_view` — see the [CLI reference](#in-place-querying).
+
+### CLI indexes carry edge metadata
+
+The `.gg` indexes written by the `idx` / `isec` CLI use `grove<interval, {bed,gff}_entry, std::string>`
+— a `std::string` graph-edge type — so that `idx --links` can attach [per-edge metadata](#cli-links).
+This changed the on-disk format from the earlier `void` edge type: **CLI-built indexes from before
+v0.25.0 must be regenerated.** (Consistent with the format-0.2 no-back-compat policy above.)
 
 ### Important Notes
 
@@ -248,7 +314,7 @@ The on-disk layout is:
 |---|---|---|---|
 | 0 | 4 | `magic` = `"GROV"` | inspectable via `xxd` / `file` |
 | 4 | 1 | `format_major` = 0 | pre-1.0; any change may break compatibility |
-| 5 | 1 | `format_minor` = 1 | starts at 0.1 |
+| 5 | 1 | `format_minor` = 2 | 0.2 = block-structured payload (was 0.1, single zlib stream) |
 | 6 | 1 | `lib_major` | informational |
 | 7 | 1 | `lib_minor` | informational |
 | 8 | 1 | `lib_patch` | informational |

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -65,7 +65,7 @@ root block id, block counts), then the payload.
 **block-structured**: each B+ tree node is an independently zlib-compressed, length-prefixed block,
 and external keys are distributed into fixed-size blocks. (Previously the whole file was a single
 zlib stream — format 0.1.) The block structure is what makes random-access partial reading possible
-— see [Partial reading with `grove_view`](#partial-reading-with-grove-view) below. Because each
+— see [Partial random-access reading](#partial-random-access-reading) below. Because each
 block is inflated from an isolated buffer of exactly its length, the source is read sequentially,
 so `grove::deserialize` now works on **non-seekable input streams** (pipes, sockets) and leaves any
 trailing bytes after the grove intact.
@@ -229,13 +229,12 @@ grove intact — the concatenated-payload pattern (registry then grove from the 
 grove payloads back-to-back, sentinel trailers) works without a seekable source.
 
 ```{note}
-Random-access *partial* reading via [`grove_view`](#partial-reading-with-grove-view) still needs a
+Random-access *partial* reading via [`grove_view`](#partial-random-access-reading) still needs a
 seekable source — it seeks to individual block offsets — which is why `grove_view::open` takes a
 file path rather than an arbitrary stream. Eager `grove::deserialize` has no such requirement.
 ```
 
-(partial-reading-with-grove-view)=
-### Partial reading with `grove_view`
+### Partial random-access reading
 
 `genogrove::structure::grove_view` is a **read-only, partial reader** over a serialized format 0.2
 `.gg`. Where `grove::deserialize` eagerly loads the whole file, `grove_view` loads only the blocks a
@@ -282,12 +281,12 @@ for (auto* k : hits.get_keys()) {
 - **Not thread-safe**, and no `flanking()` yet (eager `grove` only).
 - Requires a plain format-0.2 `.gg` written by `grove::serialize`.
 
-The CLI's `isec --in-place` is built on `grove_view` — see the [CLI reference](#in-place-querying).
+The CLI's `isec --in-place` is built on `grove_view` — see the [CLI reference](../cli.md#in-place-querying).
 
 ### CLI indexes carry edge metadata
 
 The `.gg` indexes written by the `idx` / `isec` CLI use `grove<interval, {bed,gff}_entry, std::string>`
-— a `std::string` graph-edge type — so that `idx --links` can attach [per-edge metadata](#cli-links).
+— a `std::string` graph-edge type — so that `idx --links` can attach [per-edge metadata](../cli.md#links-attaching-graph-edges).
 This changed the on-disk format from the earlier `void` edge type: **CLI-built indexes from before
 v0.25.0 must be regenerated.** (Consistent with the format-0.2 no-back-compat policy above.)
 


### PR DESCRIPTION
Batches the content-doc updates for the genogrove 0.24.8 → 0.25.x cycle (docs version already bumped to 0.25.1 on \`main\`). Verified against the genogrove **v0.25.1** headers/sources (not the issue text — the \`grove_view\` class is named \`grove_view\`, not \`lazy_grove\` as issue #183 says).

## CLI (\`source/cli.md\`)
- **\`idx --gff-name-tag <attr>\`** — GFF/GTF support for \`--links\`; required-tag rule, uniqueness/missing-attribute errors, BED-ignores-it. Closes #185.
- **\`idx --links\` optional 3rd column** — per-edge metadata (raw string), rejection rules (1/4+/empty columns), and metadata-in-dedup-key → parallel edges. Closes #186.
- **\`isec --in-place\`** — partial-read flag, its \`-i\` requirement, and the eager-vs-in-place trade-off. Closes #184.
- **Cross-type \`intersect\`** — BED↔GFF four-combination table, "output follows the target payload", and the BED/GFF → common 0-based-inclusive coordinate normalization. Closes #187.

## Serialization (\`source/guide/serialization.md\`)
- **Block-structured \`.gg\` format 0.2** — \`format_minor\` 1 → 2, block layout, no back-compat / regenerate-index warning, and the now-correct non-seekable-source behavior (replaces the stale "source must be seekable" section). Closes #182.
- **\`grove_view\`** — partial/random-access reader documented in prose: \`open(path, data_offset)\`, \`intersect\`, \`get_neighbors\`, introspection, non-copyable/non-movable + non-evicting-cache semantics. Closes #183.
- **CLI edge-type change** — indexes now carry \`std::string\` edge metadata; regenerate note.

## Notes
- **No autodoc stub for \`grove_view\`** — \`repos/genogrove\` is still at v0.24.8 (no \`grove_view.hpp\`), so a \`doxygenclass\` directive would break the build. Documented in prose for now; add the autodoc stub when the submodule is bumped.
- Cross-file references use explicit \`(label)=\` targets to avoid heading-anchor slug ambiguity (the \`grove_view\` underscore).
- #15 (thread-safety/serialization guide *pages*) intentionally left out of this batch.

Closes #182, closes #183, closes #184, closes #185, closes #186, closes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI docs for broader indexing and intersection support, including new link input options, validation rules, and cross-type query behavior.
  * Clarified serialization details for the current file format, including block-based payload structure, partial reading, and non-seekable input handling.
  * Revised format/version notes and regeneration guidance for older saved indexes and files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->