### PR TITLE
Add grove_view autodoc stub to C++ structure reference

### DIFF
--- a/source/reference/cpp/structure.md
+++ b/source/reference/cpp/structure.md
@@ -41,6 +41,20 @@ returned from functions (e.g., `grove::deserialize()`) and stored in containers.
    :undoc-members:
 ```
 
+## grove_view
+
+`grove_view` is a **read-only, partial reader** over a serialized format 0.2 `.gg`: it loads only
+the blocks a query walks instead of deserializing the whole file, complementing the eager `grove`
+(see {doc}`the serialization guide </guide/serialization>`). It is **non-copyable and non-movable**
+(it owns the file handle and a zlib state) — obtain one by value from the static `open()` factory,
+which relies on guaranteed copy elision.
+
+```{eval-rst}
+.. doxygenclass:: genogrove::structure::grove_view
+   :members:
+   :undoc-members:
+```
+
 ## node
 
 `node` is **non-copyable, move-only** (same rationale as `grove`). The move constructor and move


### PR DESCRIPTION
Follow-up to #190. The `repos/genogrove` build clone is now at **v0.25.1**, which ships `grove_view.hpp`, so breathe can render the class — adds the autodoc stub that #190 deferred (#183).

## Change
- `source/reference/cpp/structure.md` — new `## grove_view` section with a `.. doxygenclass:: genogrove::structure::grove_view` directive, plus a short intro (read-only partial reader; non-copyable/non-movable; obtained via the static `open()` factory) linking to the serialization guide.

## Notes
- Doxygen `INPUT = ./repos/genogrove/include` already covers the header; the committed (gitignored) XML confirms `grove_view` is present, and `make html` regenerates it via `update-repos` + `doxygen`.
- The `repos/genogrove` clone is a local, gitignored build input (not a tracked submodule), so the "bump to 0.25.1" is just its checkout — nothing to commit for it. This PR is the stub only.