### PR TITLE
Document pygenogrove GroveView (partial random-access .gg reader)

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -14,7 +14,7 @@ copyright = "2026, Richard. A. Schaefer"
 author = "Richard. A. Schaefer"
 release = "0.25.1"
 # pygenogrove (Python bindings) versions independently of the C++ library and
-# currently lags it; the Python guide tabs reflect this surface. Bump alongside
+# currently lags it; the Python guide tabs reflect this surface. Bump alongsid    e
 # the pin in source/requirements.txt.
 pygenogrove_release = "0.6.3"
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -16,7 +16,7 @@ release = "0.25.1"
 # pygenogrove (Python bindings) versions independently of the C++ library and
 # currently lags it; the Python guide tabs reflect this surface. Bump alongsid    e
 # the pin in source/requirements.txt.
-pygenogrove_release = "0.6.3"
+pygenogrove_release = "0.7.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/guide/grove/grove.md
+++ b/source/guide/grove/grove.md
@@ -7,8 +7,6 @@ The `grove` is a specialized B+ tree optimized for genomic interval storage and 
 ::::{tab-item} {{ cpp_tab }}
 :sync: cpp
 
-The `grove` is a specialized B+ tree optimized for genomic interval storage and querying. It organizes data by index (e.g., chromosome) and supports efficient overlap queries. An embedded graph overlay allows you to create directed edges between keys, representing relationships between genomic features.
-
 Beyond the core data structure covered on this page, the grove also supports:
 
 - **{doc}`graph`** — Create directed edges between keys to represent relationships such as transcript structures or gene regulatory networks

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -407,7 +407,7 @@ by a C++ `grove<genomic_coordinate, std::string>`; with labelled edges the inter
 `grove<genomic_coordinate, std::string, std::string>`. Typed `BedGrove` / `GffGrove` `.gg` files
 round-trip the structured `BedEntry` / `GffEntry` payloads.
 
-### Partial random-access reading
+### Partial random-access reading with `GroveView`
 
 `GroveView` is a **read-only, partial reader** over a serialized format 0.2 `.gg`. Where
 `Grove.deserialize()` loads the whole grove into memory, a `GroveView` reads only the block

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -407,6 +407,60 @@ by a C++ `grove<genomic_coordinate, std::string>`; with labelled edges the inter
 `grove<genomic_coordinate, std::string, std::string>`. Typed `BedGrove` / `GffGrove` `.gg` files
 round-trip the structured `BedEntry` / `GffEntry` payloads.
 
+### Partial random-access reading
+
+`GroveView` is a **read-only, partial reader** over a serialized format 0.2 `.gg`. Where
+`Grove.deserialize()` loads the whole grove into memory, a `GroveView` reads only the block
+directory up front and pages in individual blocks on demand as a query descends the tree, caching
+them for the view's lifetime (no eviction). Use it to query a large on-disk index without
+materializing it. It complements — does not replace — the eager `Grove`, which stays the builder
+and the load-it-all reader.
+
+There is one view class per grove flavour — `GroveView`, `NumericGroveView`, `KmerGroveView`,
+`BedGroveView`, `GffGroveView` — each reusing the `Key` / `QueryResult` types of the matching grove.
+
+```python
+import pygenogrove as pg
+
+# Open a .gg written by Grove.serialize() (a bare grove stream — data_offset=0).
+view = pg.GroveView.open("index.gg")
+
+# Same intersect() signatures/semantics as Grove — loads only the descent path
+# plus overlapping leaves. Pass an index name, or omit it to search all indices.
+hits = view.intersect(pg.GenomicCoordinate("*", 100, 200), "chr1")
+
+# Outgoing graph neighbours; pages in each target's block on demand, across chromosomes.
+for key in hits:
+    for nbr in view.get_neighbors(key):
+        ...
+
+# Proof the query was partial: only a subset of blocks was paged in.
+assert view.blocks_loaded() < view.block_count()
+```
+
+**Surface** (query-only — a view has no `insert()` or `serialize()`):
+
+- `GroveView.open(path, data_offset=0)` *(static)* — open a `.gg` for partial reading. `path` is a
+  file written by `Grove.serialize()` (use `data_offset=0`); pass a non-zero `data_offset` only for
+  a `.gg` embedded behind a leading header, e.g. a genogrove CLI index. Raises `RuntimeError` on a
+  missing file, bad magic, a non-seekable source, or a malformed directory.
+- `intersect(query)` / `intersect(query, index)` — same results as the eager `Grove`, loading only
+  the blocks the search touches.
+- `get_neighbors(key)` — the target keys directly reachable from `key` via graph edges, paging in
+  each target's block on demand. `key` must be one this view produced (from `intersect()` or a prior
+  `get_neighbors()`). Raises `TypeError` if `key` is `None`.
+- `blocks_loaded()` / `block_count()` — partial-load counters (`block_count()` is `0` for an empty
+  grove).
+
+:::{warning}
+**Not thread-safe.** A query mutates the view's block cache and holds the GIL, so concurrent Python
+threads serialize on view I/O — use **one view per thread**. The Keys a view returns point into its
+own storage and are valid only while the `GroveView` is alive.
+:::
+
+Requires a format 0.2 `.gg` (genogrove v0.25.x). See the C++ tab for the underlying `grove_view`,
+and the {doc}`Python API reference </reference/python/grove>`.
+
 ### SIF export (visualization)
 
 `grove.to_sif(path)` writes the grove to a **SIF** (Simple Interaction Format) text file for

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -458,7 +458,8 @@ threads serialize on view I/O — use **one view per thread**. The Keys a view r
 own storage and are valid only while the `GroveView` is alive.
 :::
 
-Requires a format 0.2 `.gg` (genogrove v0.25.x). See the C++ tab for the underlying `grove_view`.
+Requires a format 0.2 `.gg` (genogrove v0.25.x). See the C++ tab for the underlying `grove_view`,
+and the {doc}`Python API reference </reference/python/grove>` for the full class listing.
 
 ### SIF export (visualization)
 

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -458,8 +458,7 @@ threads serialize on view I/O — use **one view per thread**. The Keys a view r
 own storage and are valid only while the `GroveView` is alive.
 :::
 
-Requires a format 0.2 `.gg` (genogrove v0.25.x). See the C++ tab for the underlying `grove_view`,
-and the {doc}`Python API reference </reference/python/grove>`.
+Requires a format 0.2 `.gg` (genogrove v0.25.x). See the C++ tab for the underlying `grove_view`.
 
 ### SIF export (visualization)
 

--- a/source/reference/python/grove.md
+++ b/source/reference/python/grove.md
@@ -13,6 +13,17 @@ model, insertion modes, and the graph overlay.
 .. autoclass:: pygenogrove.KmerGrove
 ```
 
+## Grove views (partial random-access readers)
+
+Read-only, partial readers over a serialized `.gg` — page in only the blocks a
+query touches. See the {doc}`Serialization guide </guide/serialization>`.
+
+```{eval-rst}
+.. autoclass:: pygenogrove.GroveView
+.. autoclass:: pygenogrove.NumericGroveView
+.. autoclass:: pygenogrove.KmerGroveView
+```
+
 ## Keys
 
 ```{eval-rst}

--- a/source/reference/python/grove.md
+++ b/source/reference/python/grove.md
@@ -13,17 +13,6 @@ model, insertion modes, and the graph overlay.
 .. autoclass:: pygenogrove.KmerGrove
 ```
 
-## Grove views (partial random-access readers)
-
-Read-only, partial readers over a serialized `.gg` — page in only the blocks a
-query touches. See the {doc}`Serialization guide </guide/serialization>`.
-
-```{eval-rst}
-.. autoclass:: pygenogrove.GroveView
-.. autoclass:: pygenogrove.NumericGroveView
-.. autoclass:: pygenogrove.KmerGroveView
-```
-
 ## Keys
 
 ```{eval-rst}

--- a/source/reference/python/typed_groves.md
+++ b/source/reference/python/typed_groves.md
@@ -12,16 +12,6 @@ wrappers, and the structured record types they carry. See the
 .. autoclass:: pygenogrove.GffGrove
 ```
 
-## Grove views (partial random-access readers)
-
-Read-only, partial readers over a serialized `.gg`. See the
-{doc}`Serialization guide </guide/serialization>`.
-
-```{eval-rst}
-.. autoclass:: pygenogrove.BedGroveView
-.. autoclass:: pygenogrove.GffGroveView
-```
-
 ## Keys and results
 
 ```{eval-rst}

--- a/source/reference/python/typed_groves.md
+++ b/source/reference/python/typed_groves.md
@@ -12,6 +12,16 @@ wrappers, and the structured record types they carry. See the
 .. autoclass:: pygenogrove.GffGrove
 ```
 
+## Grove views (partial random-access readers)
+
+Read-only, partial readers over a serialized `.gg`. See the
+{doc}`Serialization guide </guide/serialization>`.
+
+```{eval-rst}
+.. autoclass:: pygenogrove.BedGroveView
+.. autoclass:: pygenogrove.GffGroveView
+```
+
 ## Keys and results
 
 ```{eval-rst}

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -9,4 +9,4 @@ sphinx-design>=0.5.0
 # If it cannot be installed/imported, conf.py skips that section gracefully.
 # Pinned to the surface the reference docs were written against (avoids autodoc
 # drifting to a newer PyPI release than the documented API).
-pygenogrove==0.6.3
+pygenogrove==0.7.0


### PR DESCRIPTION
Documents the pygenogrove `GroveView` surface added in [pygenogrove #57](https://github.com/genogrove/pygenogrove/pull/57) — the Python binding of genogrove's `grove_view` (partial/random-access reader over a serialized format 0.2 `.gg`).

### Added
- **`source/guide/serialization.md`** (Python tab) — a "Partial random-access reading" section: one view class per grove flavour (`GroveView` / `NumericGroveView` / `KmerGroveView` / `BedGroveView` / `GffGroveView`), a worked `open` → `intersect` → `get_neighbors` → block-counter example, and the full query-only surface with error behaviour. Flags **not thread-safe → one view per thread** and the Key-valid-only-while-view-alive lifetime.

Mirrors the existing C++ `grove_view` docs already in the serialization guide and `reference/cpp/structure.md`.

### Deferred (not in this PR)
The `autodoc` reference stubs (`reference/python/{grove,typed_groves}.md`) are **not** included: those pages are generated from the installed `pygenogrove`, and GroveView ships in a wheel later than the current build env (0.6.0), so the directives fail to import and warn. Re-add the 5 `autoclass` lines alongside the next pygenogrove wheel/submodule bump — note the local `repos/pygenogrove` checkout is also stale (pre-#57).

Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for partial random-access reading of `.gg` format 0.2 files using `GroveView` and related view types.
  * Documented supported operations, usage examples, caching behavior, limitations, errors, and thread-safety considerations.
  * Clarified compatibility requirements and the lifetime of keys returned by partial views.
  * Improved formatting of an internal configuration comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->