### PR TITLE
Fix broken code examples in index.md and performance.md

### DIFF
--- a/source/guide/performance.md
+++ b/source/guide/performance.md
@@ -292,11 +292,11 @@ import pygenogrove as pg
 g = pg.Grove()
 
 # Bulk load: per-index (one chromosome at a time), built bottom-up
-items = [(pg.Interval(i * 100, i * 100 + 50), f"feature{i}") for i in range(1_000_000)]
+items = [(pg.GenomicCoordinate('+', i * 100, i * 100 + 50), f"feature{i}") for i in range(1_000_000)]
 g.insert_bulk("chr1", items, presorted=True)   # presorted skips the internal sort
 
 # Rightmost-append fast path for incremental sorted inserts
-g.insert_sorted("chr2", pg.Interval(100, 200), "feat")
+g.insert_sorted("chr2", pg.GenomicCoordinate('+', 100, 200), "feat")
 ```
 
 - `insert_bulk` is **per-index** — call it once per chromosome / contig.

--- a/source/index.md
+++ b/source/index.md
@@ -44,7 +44,7 @@ int main() {
             features.insert_data(
                 entry.chrom,
                 gdt::interval(entry.start, entry.end - 1),
-                entry.name,
+                entry.name.value_or("unnamed"),
                 gst::sorted  // Optimized for pre-sorted data
             );
         }


### PR DESCRIPTION
Fixes the two broken code examples found by `/docs-sync`.

## Changes
- **`source/index.md`** — C++ quick example passed `entry.name` (a `std::optional<std::string>`) directly as the `std::string` payload into `grove<interval, std::string>` — a type mismatch that won't compile. Now uses `entry.name.value_or("unnamed")`, matching every other C++ page.
- **`source/guide/performance.md`** — Python example used `pg.Interval(...)`, a type removed from pygenogrove (the universal `Grove` is keyed by `GenomicCoordinate`; `tests/test_imports.py` asserts `Interval` is gone). Both calls would raise `AttributeError` at runtime. Now uses `pg.GenomicCoordinate('+', ...)`.

No API changes — the docs were stale, the code is correct.

Closes #205. See also closed #10 (same category).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the performance guide’s bulk and fast-path insert examples to use genomic coordinates consistently.
  * Improved the Quick Example by showing how unnamed entries are automatically labeled “unnamed” when no feature name is provided.
  * Clarified example behavior while preserving the existing insertion workflows and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->