### PR TITLE
Document grove_view::flanking, BED/GFF error semantics, and CLI --version

### DIFF
--- a/source/cli.md
+++ b/source/cli.md
@@ -2,6 +2,24 @@
 
 The genogrove command-line interface provides tools for indexing and querying genomic interval files.
 
+## Global options
+
+- `-v, --version`: Print the genogrove version (`genogrove <major>.<minor>.<patch>`) and exit 0.
+
+```bash
+genogrove --version
+# genogrove 0.25.3
+```
+
+**Invalid arguments** — an unrecognized flag, a non-integer value for an integer option (e.g. `-k foo`),
+or a missing option argument reports the error on stderr and exits with status 1:
+
+```bash
+genogrove idx -k foo input.bed
+# error: invalid value 'foo' for --order
+# exit status: 1
+```
+
 ## Commands
 
 ### idx (Index)

--- a/source/guide/io.md
+++ b/source/guide/io.md
@@ -122,6 +122,19 @@ try {
 
 This pattern applies to all readers (`bed_reader`, `gff_reader`, `bam_reader`).
 
+For `bed_reader` and `gff_reader`, a mid-stream BGZF/tabix I/O error thrown from `read_next()` also
+records its message in the reader before propagating, so a caller that catches the exception can
+retrieve it via `get_error_message()` — matching the `bam_reader`/`vcf_reader` behavior:
+
+```cpp
+try {
+    for (const auto& entry : reader) { /* ... */ }
+} catch (const std::runtime_error& e) {
+    std::cerr << "Error: " << e.what()
+              << " (" << reader.get_error_message() << ")\n";
+}
+```
+
 #### Lenient Mode
 
 To skip malformed records instead of throwing, enable lenient mode via the reader's options struct.
@@ -142,6 +155,10 @@ for (const auto& entry : reader) {
     // process entries — malformed lines are silently skipped
 }
 ```
+
+With `skip_invalid_lines = true`, the **first** data record is no longer special: a malformed first
+record is skipped during iteration like any other invalid line. (Construction only throws on a bad
+first record when `skip_invalid_lines = false`.)
 
 #### Error Message Lifecycle
 
@@ -203,7 +220,7 @@ if (reader.begin() == reader.end()) {
 The following error conditions still throw `std::runtime_error` (or skip the line, in lenient mode):
 
 - File-open failures (missing file, permission denied, unreadable BGZF header)
-- Malformed first record that fails to parse
+- A malformed first record — only when `skip_invalid_lines = false`; in lenient mode it is skipped
 - Per-line parse errors discovered mid-iteration
 
 In other words, "valid file with zero records" is now a quiet success; only structurally broken

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -268,6 +268,12 @@ for (auto* k : hits.get_keys()) {
   or a malformed directory.
 - `intersect(const key_type& query, std::string_view index)` and `intersect(const key_type& query)`
   — same signatures and semantics as `grove::intersect` (they share the query engine).
+- `flanking(const key_type& query, std::string_view index)` and the predicate overload
+  `flanking(const key_type& query, std::string_view index, Pred is_compatible)` — nearest
+  non-overlapping predecessor/successor, same semantics as `grove::flanking` (the interval-nesting
+  predecessor rule and smallest-start successor rule are preserved; either field may be null, both
+  null if the index is absent). Because flanking can branch into both sides of the query, it may
+  page in more blocks than a single-path `intersect`.
 - `get_neighbors(const key* source)` — outgoing graph neighbours, loading only the target block
   (including across chromosomes). `source` must be a key pointer this `grove_view` produced.
 - `blocks_loaded()` / `block_count()` — introspection (e.g. to assert a query really was partial).
@@ -278,7 +284,7 @@ for (auto* k : hits.get_keys()) {
   `open()`; the return is guaranteed copy elision, so no move is needed.
 - **The block cache never evicts** — memory grows with the set of blocks touched, bounded by the
   query footprint.
-- **Not thread-safe**, and no `flanking()` yet (eager `grove` only).
+- **Not thread-safe** — a query pages in blocks on demand, so use one view per thread.
 - Requires a plain format-0.2 `.gg` written by `grove::serialize`.
 
 The CLI's `isec --in-place` is built on `grove_view` — see the [CLI reference](../cli.md#in-place-querying).

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -272,8 +272,10 @@ for (auto* k : hits.get_keys()) {
   `flanking(const key_type& query, std::string_view index, Pred is_compatible)` — nearest
   non-overlapping predecessor/successor, same semantics as `grove::flanking` (the interval-nesting
   predecessor rule and smallest-start successor rule are preserved; either field may be null, both
-  null if the index is absent). Because flanking can branch into both sides of the query, it may
-  page in more blocks than a single-path `intersect`.
+  null if the index is absent). The predicate overload's `is_compatible` is applied at leaf
+  candidates only — internal-node pruning stays purely structural (aggregate ranges) and never
+  consults the predicate, matching `grove::flanking`. Because flanking can branch into both sides of
+  the query, it may page in more blocks than a single-path `intersect`.
 - `get_neighbors(const key* source)` — outgoing graph neighbours, loading only the target block
   (including across chromosomes). `source` must be a key pointer this `grove_view` produced.
 - `blocks_loaded()` / `block_count()` — introspection (e.g. to assert a query really was partial).


### PR DESCRIPTION
Bundles three v0.25.3 content-doc issues (all additive clarifications, no conflicts).

## `grove_view::flanking` — closes #201
`source/guide/serialization.md` (C++ tab, partial-reader section): documents both overloads
`flanking(query, index)` and `flanking(query, index, is_compatible)`, same semantics as
`grove::flanking` (nesting predecessor rule, smallest-start successor, nullable fields), and the note
that flanking can page in more blocks than a single-path `intersect`. Removed the now-stale
"no `flanking()` yet" bullet. (Python `GroveView.flanking()` isn't bound yet — pygenogrove#61 — so the
Python tab is unchanged.)

## BED/GFF reader error semantics — closes #202
`source/guide/io.md`:
- Lenient mode: `skip_invalid_lines = true` now covers a malformed **first** record (skipped like any
  other line); construction only throws on a bad first record when `skip_invalid_lines = false`.
  Updated the throw-conditions list to match.
- Error handling: a mid-stream BGZF/tabix I/O error from `read_next()` now populates
  `get_error_message()` before propagating, matching `bam_reader`/`vcf_reader`.

## CLI `--version` + clean invalid-argument exit — closes #204
`source/cli.md`: new **Global options** section documenting `-v, --version` (prints
`genogrove <major>.<minor>.<patch>`, exits 0) and the invalid-argument behavior (unrecognized flag,
non-integer value, missing option arg → error on stderr, exit 1, no `std::terminate`).

All three are documentation-only; the corresponding library behavior shipped in genogrove v0.25.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added CLI documentation for global options, including `--version` output and invalid-argument behavior (errors to stderr, exit code `1`).
  - Updated the I/O guide to clarify streaming error capture/retrieval and lenient-mode edge cases for malformed or zero-record inputs.
  - Expanded serialization/`grove_view` documentation to include `flanking()` (including predicate overload), refined selection semantics, and revised thread-safety notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->