### PR TITLE
Document new grove_view accessors, fix registry thread-safety wording, bump to 0.25.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Genogrove Documentation
 
 [![Read the Docs — Genogrove documentation](https://img.shields.io/readthedocs/genogrove)](https://genogrove.readthedocs.io/)
-[![Genogrove version](https://img.shields.io/badge/genogrove-v0.25.3-green.svg)](https://github.com/genogrove/genogrove)
+[![Genogrove version](https://img.shields.io/badge/genogrove-v0.25.5-green.svg)](https://github.com/genogrove/genogrove)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Sphinx](https://img.shields.io/badge/built%20with-Sphinx-blue.svg)](https://www.sphinx-doc.org/)
 [![MyST](https://img.shields.io/badge/markup-MyST%20Markdown-purple.svg)](https://myst-parser.readthedocs.io/)

--- a/source/cli.md
+++ b/source/cli.md
@@ -8,7 +8,7 @@ The genogrove command-line interface provides tools for indexing and querying ge
 
 ```bash
 genogrove --version
-# genogrove 0.25.3
+# genogrove 0.25.5
 ```
 
 **Invalid arguments** — an unrecognized flag, a non-integer value for an integer option (e.g. `-k foo`),

--- a/source/conf.py
+++ b/source/conf.py
@@ -12,7 +12,7 @@ import os
 project = "genogrove"
 copyright = "2026, Richard. A. Schaefer"
 author = "Richard. A. Schaefer"
-release = "0.25.3"
+release = "0.25.5"
 # pygenogrove (Python bindings) versions independently of the C++ library and
 # currently lags it; the Python guide tabs reflect this surface. Bump alongsid    e
 # the pin in source/requirements.txt.

--- a/source/conf.py
+++ b/source/conf.py
@@ -16,7 +16,7 @@ release = "0.25.5"
 # pygenogrove (Python bindings) versions independently of the C++ library and
 # currently lags it; the Python guide tabs reflect this surface. Bump alongsid    e
 # the pin in source/requirements.txt.
-pygenogrove_release = "0.7.0"
+pygenogrove_release = "0.7.3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/source/guide/data_types/registry.md
+++ b/source/guide/data_types/registry.md
@@ -128,12 +128,12 @@ This pattern avoids overloading `gene_info::operator==` and `std::hash<gene_info
 
 ### Thread Safety
 
-`registry<T>` is safe to use concurrently:
+The mutex-protected methods are safe to call concurrently with one another; the unlocked fast paths are **not** safe alongside a concurrent writer:
 
 - **Lock-protected:** `intern()`, `find()`, `clear()`, `serialize()`, `deserialize()` acquire an internal `std::mutex`.
 - **Unlocked fast paths:** `get(id)`, `contains(id)`, `size()`, `empty()`.
 
-`get(id)` is safe to call concurrently with `intern()` as long as `id` was obtained from an `intern()` call that **happens-before** the `get()`. `size()`, `empty()`, and `contains()` return best-effort snapshots under concurrent writes.
+The unlocked reads are safe **only when no writer** (`intern()`, `clear()`, `reset()`, `deserialize()`) runs concurrently. An unsynchronized read that overlaps a writer's `push_back` / move-assign is a **data race — undefined behavior**, not a stale-but-defined snapshot. `get(id)` is safe once the `id` was obtained from an `intern()` call that **happens-before** the `get()` and no further mutation is in flight. (The library is single-threaded today; see the [thread-safety guide](../thread_safety.md).)
 
 ### Serialization and Deserialization
 

--- a/source/guide/data_types/registry.md
+++ b/source/guide/data_types/registry.md
@@ -130,7 +130,7 @@ This pattern avoids overloading `gene_info::operator==` and `std::hash<gene_info
 
 The mutex-protected methods are safe to call concurrently with one another; the unlocked fast paths are **not** safe alongside a concurrent writer:
 
-- **Lock-protected:** `intern()`, `find()`, `clear()`, `serialize()`, `deserialize()` acquire an internal `std::mutex`.
+- **Lock-protected:** `intern()`, `find()`, `clear()`, `serialize()` acquire an internal `std::mutex`. `deserialize()` does its I/O and parsing **outside** the lock, taking it only for the final commit (move-assign), so it does not serialize concurrent registry access during the read.
 - **Unlocked fast paths:** `get(id)`, `contains(id)`, `size()`, `empty()`.
 
 The unlocked reads are safe **only when no writer** (`intern()`, `clear()`, `reset()`, `deserialize()`) runs concurrently. An unsynchronized read that overlaps a writer's `push_back` / move-assign is a **data race — undefined behavior**, not a stale-but-defined snapshot. `get(id)` is safe once the `id` was obtained from an `intern()` call that **happens-before** the `get()` and no further mutation is in flight. (The library is single-threaded today; see the [thread-safety guide](../thread_safety.md).)

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -277,7 +277,23 @@ for (auto* k : hits.get_keys()) {
   consults the predicate, matching `grove::flanking`. Because flanking can branch into both sides of
   the query, it may page in more blocks than a single-path `intersect`.
 - `get_neighbors(const key* source)` — outgoing graph neighbours, loading only the target block
-  (including across chromosomes). `source` must be a key pointer this `grove_view` produced.
+  (including across chromosomes). `source` must be a key pointer this `grove_view` produced. Throws
+  `std::invalid_argument` on a null source.
+- `get_edges(const key* source)` — the edge-metadata payloads for `source`'s outgoing edges, in
+  adjacency order (edge-carrying views only, i.e. `edge_data_type != void`). Returns an empty vector
+  for a null source — it does **not** throw, unlike the target-resolving accessors.
+- `get_neighbors_if(const key* source, Pred pred)` — neighbours whose edge metadata satisfies
+  `pred(const edge_data_type&)` (edge-carrying views only). Throws `std::invalid_argument` on a null
+  source.
+- `get_edge_list(const key* source)` — each outgoing target paired with its edge metadata
+  (`std::vector<std::pair<key* , edge_data_type>>`) in one call, in adjacency order (edge-carrying
+  views only). Resolves targets on demand like `get_neighbors`. Throws `std::invalid_argument` on a
+  null source — note this differs from `graph_overlay::get_edge_list`, which returns an empty vector.
+- `get_order()` — the B+ tree order the `.gg` was built with (same value the eager `grove` reports).
+- `get_index_names()` — the names of every index (e.g. chromosome) in the file, in **unspecified
+  order**; use it to discover what `intersect` / `flanking` can run against. Reads nothing beyond the
+  directory already loaded at `open()`. (Unlike `grove::get_root_nodes()`, which hands back live node
+  pointers, the view returns a copied name list — a lazy reader has no persistent root nodes.)
 - `blocks_loaded()` / `block_count()` — introspection (e.g. to assert a query really was partial).
 
 **Semantics worth calling out:**

--- a/source/guide/serialization.md
+++ b/source/guide/serialization.md
@@ -472,6 +472,10 @@ assert view.blocks_loaded() < view.block_count()
   missing file, bad magic, a non-seekable source, or a malformed directory.
 - `intersect(query)` / `intersect(query, index)` — same results as the eager `Grove`, loading only
   the blocks the search touches.
+- `flanking(query, index)` / `flanking(query, index, is_compatible)` — nearest non-overlapping
+  predecessor/successor, the same `FlankingResult` the eager `Grove.flanking()` returns, paging in
+  only the descent-path blocks. The optional `is_compatible` predicate is applied at leaf candidates
+  only (e.g. same-strand neighbours).
 - `get_neighbors(key)` — the target keys directly reachable from `key` via graph edges, paging in
   each target's block on demand. `key` must be one this view produced (from `intersect()` or a prior
   `get_neighbors()`). Raises `TypeError` if `key` is `None`.
@@ -484,13 +488,21 @@ assert view.blocks_loaded() < view.block_count()
   `get_neighbors`. The predicate receives the **decoded** payload — which is `None` for an edge added
   without one, so guard for it when mixing labelled and unlabelled edges. Raises `TypeError` if
   `source` is `None`. **Edge-carrying views only** (see below).
+- `get_edge_list(source) -> list` — `source`'s outgoing edges as `(target Key, metadata)` pairs — the
+  zip of `get_neighbors(source)` and `get_edges(source)` — paging in each target's block on demand.
+  Mirrors the mutable `Grove.get_edge_list`; edges added without a payload yield `None` metadata,
+  raises `TypeError` if `source` is `None`. **Edge-carrying views only** (see below).
+- `get_order()` — the B+ tree order the `.gg` was built with (mirrors `Grove.get_order()`), read from
+  the directory loaded at `open()` — no extra blocks paged in.
+- `get_index_names()` — the names of every index (chromosome) in the file, so a caller can discover
+  what `intersect` / `flanking` can run against. Read straight from the loaded directory.
 - `blocks_loaded()` / `block_count()` — partial-load counters (`block_count()` is `0` for an empty
   grove).
 
-`get_edges` / `get_neighbors_if` exist only on the **universal `GroveView`** (and its point-key
-siblings `NumericGroveView` / `KmerGroveView`), whose edges carry a payload. The typed
+`get_edges` / `get_neighbors_if` / `get_edge_list` exist only on the **universal `GroveView`** (and
+its point-key siblings `NumericGroveView` / `KmerGroveView`), whose edges carry a payload. The typed
 `BedGroveView` / `GffGroveView` keep unlabelled (void) edges for binary interop, so — mirroring the
-mutable `BedGrove` / `GffGrove` — the two labelled-edge reads are absent there; use `get_neighbors`
+mutable `BedGrove` / `GffGrove` — the labelled-edge reads are absent there; use `get_neighbors`
 to traverse. These accessors match the mutable `Grove`'s adjacency surface (see the
 {doc}`graph guide </guide/grove/graph>`), but query-only.
 

--- a/source/guide/thread_safety.md
+++ b/source/guide/thread_safety.md
@@ -70,8 +70,11 @@ internal `std::mutex` (one global lock — not sharded, not per-index):
 - **Locked:** `intern()`, `find()`, `clear()`, `serialize()`, and the commit step of `deserialize()`.
   `deserialize()` builds into local temporaries and only takes the lock for a brief move-assign, so it
   does not block concurrent `intern`/`find` during I/O.
-- **Unlocked fast paths:** `get(id)`, `contains(id)`, `size()`, `empty()`. `get(id)` is safe alongside
-  concurrent `intern()` **only if** the `id` came from an `intern()` that happens-before the `get()`.
+- **Unlocked fast paths:** `get(id)`, `contains(id)`, `size()`, `empty()`. These are safe **only when
+  no writer** (`intern`/`clear`/`reset`/`deserialize`) runs concurrently — an unlocked read overlapping
+  a writer's `push_back`/move-assign is a **data race (undefined behavior)**, not a best-effort
+  snapshot. `get(id)` is safe once the `id` came from an `intern()` that happens-before the `get()` and
+  no further mutation is in flight.
 
 Because it is a single global mutex, heavy concurrent interning serializes on it.
 

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -9,4 +9,4 @@ sphinx-design>=0.5.0
 # If it cannot be installed/imported, conf.py skips that section gracefully.
 # Pinned to the surface the reference docs were written against (avoids autodoc
 # drifting to a newer PyPI release than the documented API).
-pygenogrove==0.7.0
+pygenogrove==0.7.3


### PR DESCRIPTION
Addresses all open docs issues in one pass, plus a pygenogrove version/surface catch-up.

## grove_view accessors — `guide/serialization.md` C++ surface (closes #209, closes #211)
The hand-maintained C++ **Public surface** list lagged the real `grove_view` API and the Python tab. Added:
- `get_edge_list` — targets paired with edge metadata; throws `std::invalid_argument` on null (differs from `graph_overlay::get_edge_list`, which returns empty) — **#209**
- `get_order` / `get_index_names` — read-side introspection — **#211**
- `get_edges` / `get_neighbors_if` — edge-payload accessors the Python tab already documented (tracked by the now-closed #197, but the C++ tab was never updated)

## registry thread-safety (closes #212)
`guide/data_types/registry.md` and `guide/thread_safety.md` described the unlocked fast paths (`get`/`contains`/`size`/`empty`) as returning "best-effort snapshots" under concurrent writes. Corrected: an unlocked read overlapping a writer (`intern`/`clear`/`reset`/`deserialize`) is a **data race — undefined behavior**. Safe only in the absence of a concurrent writer.

## genogrove version bump (closes #213, closes #210)
`conf.py` `release` and the README badge: `0.25.3 → 0.25.5`.

## pygenogrove version + Python GroveView surface
pygenogrove `0.7.0 → 0.7.3` added Python surface the docs never picked up. Added to the Python `GroveView` list in `serialization.md`:
- `GroveView.flanking(query, index[, is_compatible])` (0.7.2)
- `GroveView.get_edge_list` / `get_order` / `get_index_names` (0.7.3)

Bumped the stamp in `conf.py` (`pygenogrove_release`) and the `source/requirements.txt` pin to `0.7.3`.